### PR TITLE
Add bahnpark v2.3 converter

### DIFF
--- a/new/bahn.geojson
+++ b/new/bahn.geojson
@@ -4,13 +4,179 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100001",
+        "name": "Parkplatz Aalen Hauptbahnhof Rückseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100001",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100001/prognoses",
+        "address": "Hirschbachstraße, 73431 Aalen",
+        "capacity": 55,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 5.00€, 1 Woche: 25.00€, 1 Monat (am Automaten): 44.00€, 1 Monat Dauerparken (mind. 3 Monate): 44.00€, 1 Monat Dauerparken (fester Stellplatz): 78.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.097189,
+          48.839307
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100002",
+        "name": "Parkplatz Bahnhof Amberg",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100002",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100002/prognoses",
+        "address": "Kaiser-Ludwig-Ring, 92224 Amberg",
+        "capacity": 51,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 6.50€, 1 Woche: 32.50€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.863333,
+          49.446586
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100003",
+        "name": "Parkplatz Bahnhof Ansbach Empfangsgeb.",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100003",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100003/prognoses",
+        "address": "Bahnhofsplatz 2, 91522 Ansbach",
+        "capacity": 42,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 6.00€, 1 Woche: 24.00€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 45.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.57871,
+          49.298654
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100004",
+        "name": "Bahnhof Ansbach Turnitzstraße am Gleis",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100004",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100004/prognoses",
+        "address": "Bahnhofsplatz/Turnitzstraße, 91522 Ansbach",
+        "capacity": 30,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 6.00€, 1 Woche: 24.00€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 45.00€, 1 Monat Dauerparken (fester Stellplatz): 65.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.576573,
+          49.298149
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100005",
+        "name": "Parkplatz Bahnhof Ansbach Turnitzstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100005",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100005/prognoses",
+        "address": "Turnitzstraße, 91522 Ansbach",
+        "capacity": 59,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 5.00€, 1 Woche: 20.00€, 1 Monat (am Automaten): 42.00€, 1 Monat Dauerparken (mind. 3 Monate): 42.00€, 1 Monat Dauerparken (fester Stellplatz): 65.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.57459,
+          49.298395
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100006",
         "name": "Parkhaus Aschaffenburg Hauptbahnhof",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100006",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Aschaffenburg\n63739\nLudwigstraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100006/prognoses",
+        "address": "Ludwigstraße, 63739 Aschaffenburg",
         "capacity": 459,
+        "capacity_disabled": 5,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.70€, 1 Tag: 15.00€, 1 Tag rabattiert: 11.00€, 1 Monat Dauerparken (mind. 3 Monate): 120.00€, 1 Monat Dauerparken (fester Stellplatz): 200.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -24,13 +190,365 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100007",
+        "name": "Parkplatz Aschaffenburg Kolbornstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100007",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100007/prognoses",
+        "address": "Kolbornstraße, 63739 Aschaffenburg",
+        "capacity": 33,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 5.00€, 1 Woche: 35.00€, 1 Monat Dauerparken (mind. 3 Monate): 95.00€, 1 Monat Dauerparken (fester Stellplatz): 125.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.151899,
+          49.980491
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100009",
+        "name": "Parkplatz Bahnhof Aulendorf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100009",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100009/prognoses",
+        "address": "Waldseer Straße, 88326 Aulendorf",
+        "capacity": 42,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.00€, 1 Woche: 12.00€, 1 Monat (am Automaten): 15.00€, 1 Monat Dauerparken (mind. 3 Monate): 15.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.64376,
+          47.953787
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100011",
+        "name": "Parkplatz Bad Hersfeld Bahnhofsplatz",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100011",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100011/prognoses",
+        "address": "Bahnhofsplatz, 36251 Bad Hersfeld",
+        "capacity": 41,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.00€, 1 Woche: 12.00€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€, 1 Monat Dauerparken (fester Stellplatz): 80.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.716196,
+          50.870441
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100012",
+        "name": "Vorfahrt Bahnhof Bad Kreuznach",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100012",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100012/prognoses",
+        "address": "Europaplatz, 55543 Bad Kreuznach",
+        "capacity": 16,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.40€, 1 Tag: 7.50€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.865589,
+          49.842331
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100013",
+        "name": "Parkplatz Bahnhof Bad Kreuznach",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100013",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100013/prognoses",
+        "address": "Europaplatz, 55543 Bad Kreuznach",
+        "capacity": 54,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.40€, 1 Tag: 6.00€, 1 Woche: 30.00€, 1 Monat (am Automaten): 70.00€, 1 Monat Dauerparken (mind. 3 Monate): 70.00€, 1 Monat Dauerparken (fester Stellplatz): 110.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.865287,
+          49.84152
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100014",
+        "name": "Bahnhof Bad Oldesloe zwischen den Gleisen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100014",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100014/prognoses",
+        "address": "Mommsenstraße, 23843 Bad Oldesloe",
+        "capacity": 28,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.50€, 1 Stunde: 1.00€, 1 Tag: 3.50€, 1 Woche: 17.50€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.382825,
+          53.805962
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100015",
+        "name": "Bahnhof Bad Oldesloe in Zufahrt",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100015",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100015/prognoses",
+        "address": "Mommsenstraße, 23843 Bad Oldesloe",
+        "capacity": 14,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.50€, 1 Stunde: 1.00€, 1 Tag: 3.50€, 1 Woche: 17.50€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.383452,
+          53.806651
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100016",
+        "name": "Bahnhof Bamberg Vorplatz",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100016",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100016/prognoses",
+        "address": "Ludwigstraße, 96052 Bamberg",
+        "capacity": 37,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.20€, 1 Stunde: 2.40€, 1 Tag: 7.50€, 1 Woche: 49.00€, 1 Monat Dauerparken (mind. 3 Monate): 80.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.899193,
+          49.900187
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100017",
+        "name": "Parkplatz Bahnhof Bamberg links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100017",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100017/prognoses",
+        "address": "Ludwigstraße, 96052 Bamberg",
+        "capacity": 80,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 11 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.20€, 1 Stunde: 2.40€, 1 Tag: 6.50€, 1 Woche: 30.00€, 1 Monat (am Automaten): 60.00€, 1 Monat Dauerparken (mind. 3 Monate): 60.00€, 1 Monat Dauerparken (fester Stellplatz): 110.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.898195,
+          49.900974
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100018",
+        "name": "Bayreuth Hbf Vorfahrt",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100018",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100018/prognoses",
+        "address": "Bahnhofstraße, 95444 Bayreuth",
+        "capacity": 15,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 10.00€, 1 Woche: 70.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.579322,
+          49.94969
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100021",
+        "name": "Parkplatz Bahnhof Böblingen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100021",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100021/prognoses",
+        "address": "Talstraße, 71032 Böblingen",
+        "capacity": 30,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 12.00€, 1 Woche: 60.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.005583,
+          48.68791
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100022",
         "name": "Parkhaus Berlin Hauptbahnhof",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100022",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Berlin\n10557\nClara-Jaschke-Straße / B-96-Tunnel\nunterirdisch im B-96-Tunnel; oberirdisch Clara-Jaschke-Straße\nunderground in the B96 tunnel; overground in Clara-Jaschke-Straße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100022/prognoses",
+        "address": "Clara-Jaschke-Straße / B-96-Tunnel, 10557 Berlin",
         "capacity": 860,
+        "capacity_disabled": 28,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 3.00€, 1 Tag: 27.00€, 1 Tag rabattiert: 21.00€, 1 Woche: 55.00€, 1 Woche rabattiert: 49.00€, 1 Monat Dauerparken (mind. 3 Monate): 225.00€, 1 Monat Dauerparken (fester Stellplatz): 280.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -48,10 +566,21 @@
         "name": "Parkplatz Berlin Ostbahnhof",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100023",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Berlin\n10243\nAm Ostbahnhof",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100023/prognoses",
+        "address": "Am Ostbahnhof, 10243 Berlin",
         "capacity": 113,
-        "has_live_capacity": true
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Einfach parken! (Kurzanleitung als PDF)",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.80€, 1 Tag: 8.00€, 1 Tag rabattiert: 6.00€, 1 Monat Dauerparken (mind. 3 Monate): 120.00€, 1 Monat Dauerparken (fester Stellplatz): 195.00€",
+        "park_ride": true,
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -68,9 +597,20 @@
         "name": "Tiefgarage Berlin Ostbahnhof",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100024",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Berlin\n10243\nStralauer Platz/Am Ostbahnhof",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100024/prognoses",
+        "address": "Stralauer Platz/Am Ostbahnhof, 10243 Berlin",
         "capacity": 230,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.80€, 1 Tag: 8.00€, 1 Tag rabattiert: 6.00€, 1 Monat Dauerparken (mind. 3 Monate): 120.00€, 1 Monat Dauerparken (fester Stellplatz): 195.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -86,11 +626,22 @@
       "properties": {
         "id": "db-100025",
         "name": "Parkhaus Bahnhof Berlin Südkreuz",
-        "type": "level",
+        "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100025",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Berlin\n10829\nLotte-Laserstein-Straße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100025/prognoses",
+        "address": "Lotte-Laserstein-Straße, 10829 Berlin",
         "capacity": 213,
+        "capacity_disabled": 6,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.20€, 1 Tag: 23.00€, 1 Tag rabattiert: 19.00€, 1 Monat Dauerparken (mind. 3 Monate): 250.00€, 1 Monat Dauerparken (fester Stellplatz): 320.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -104,13 +655,179 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100026",
+        "name": "Bahnhof Berlin Südkreuz Vorfahrt West",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100026",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100026/prognoses",
+        "address": "Lotte-Laserstein-Straße, 10829 Berlin",
+        "capacity": 6,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Tag",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.50€, 1 Tag: 30.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.363993,
+          52.475219
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100027",
+        "name": "Bahnhof Berlin Südkreuz Vorfahrt Ost",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100027",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100027/prognoses",
+        "address": "Erika-Gräfin-von-Brockdorff-Platz, 12101 Berlin",
+        "capacity": 20,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.50€, 1 Tag: 27.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.366233,
+          52.475627
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100028",
+        "name": "Bahnhof Berlin Südkreuz Kiss&Ride Ost",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100028",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100028/prognoses",
+        "address": "Erika-Gräfin-von-Brockdorff-Platz, 10829 Berlin",
+        "capacity": 8,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Tag",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.50€, 1 Tag: 27.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.366469,
+          52.475295
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100029",
+        "name": "Parkplatz Bahnhof Flughafen BER - Terminal 5 (Schönefeld)",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100029",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100029/prognoses",
+        "address": "Mittelstraße (B96a), 12529 Schönefeld",
+        "capacity": 75,
+        "capacity_disabled": 3,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 11 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 5.00€, 1 Woche: 24.00€, 1 Monat (am Automaten): 48.00€, 1 Monat Dauerparken (mind. 3 Monate): 48.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.511957,
+          52.38999
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100030",
+        "name": "Parkhaus Stadthalle Bielefeld",
+        "type": "garage",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100030/prognoses",
+        "address": "Nahariyastraße, 33602 Bielefeld",
+        "capacity": 444,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "",
+        "operator": "ORBE Parkgaragen II OHG",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 10.00€, 1 Tag rabattiert: 7.50€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.535641,
+          52.029435
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100031",
-        "name": "Parkhaus Stuttgarter Straße Süd",
+        "name": "Bahnhof Bietigheim-Bissingen Parkhaus Süd",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100031",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Bietigheim-Bissingen\n74321\nStuttgarter Straße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100031/prognoses",
+        "address": "Stuttgarter Straße, 74321 Bietigheim-Bissingen",
         "capacity": 291,
+        "capacity_disabled": 4,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Nahtlos umsteigen - kontaktlos zahlen",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.60€, 1 Tag: 3.20€, 1 Woche: 16.00€, 1 Monat Dauerparken (mind. 3 Monate): 45.00€, 1 Monat Dauerparken (fester Stellplatz): 70.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -124,13 +841,241 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100032",
+        "name": "Vorplatz Bingen (Rhein) Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100032",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100032/prognoses",
+        "address": "Bingerbrücker Straße, 55411 Bingen am Rhein",
+        "capacity": 12,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 7.50€, 1 Woche: 37.50€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.884668,
+          49.968506
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100033",
+        "name": "Parkplatz Bingen (Rhein) Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100033",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100033/prognoses",
+        "address": "Bingerbrücker Straße, 55411 Bingen am Rhein",
+        "capacity": 75,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.20€, 1 Tag: 6.50€, 1 Woche: 26.00€, 1 Monat (am Automaten): 48.00€, 1 Monat Dauerparken (mind. 3 Monate): 48.00€, 1 Monat Dauerparken (fester Stellplatz): 80.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.886195,
+          49.968198
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100034",
+        "name": "Bochum Hbf Parkplatz Klever Weg",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100034",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100034/prognoses",
+        "address": "Klever Weg, 44789 Bochum",
+        "capacity": 89,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.60€, 1 Tag: 7.50€, 1 Woche: 37.50€, 1 Monat (am Automaten): 110.00€, 1 Monat Dauerparken (mind. 3 Monate): 110.00€, 1 Monat Dauerparken (fester Stellplatz): 160.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.220657,
+          51.47674
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100036",
+        "name": "Bahnhof Bad Godesberg Vorderseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100036",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100036/prognoses",
+        "address": "Moltkestraße, 53173 Bonn",
+        "capacity": 27,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 11 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 4.50€, 1 Woche: 22.50€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 45.00€, 1 Monat Dauerparken (fester Stellplatz): 85.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.160621,
+          50.682847
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100037",
+        "name": "Bahnhof Bad Godesberg Von-Groote-Platz Süd",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100037",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100037/prognoses",
+        "address": "Von-Groote-Platz 4, 53173 Bonn",
+        "capacity": 70,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 3.00€, 1 Woche: 15.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€, 1 Monat Dauerparken (fester Stellplatz): 60.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.161051,
+          50.683587
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100038",
+        "name": "Bahnhof Bad Godesberg Von-Groote-Platz",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100038",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100038/prognoses",
+        "address": "Von-Groote-Platz 1, 53173 Bonn",
+        "capacity": 60,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 3.00€, 1 Woche: 15.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€, 1 Monat Dauerparken (fester Stellplatz): 60.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.159511,
+          50.684606
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100039",
+        "name": "Parkplatz Bahnhof Bonn-Mehlem",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100039",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100039/prognoses",
+        "address": "Mainzer Straße, 53179 Bonn",
+        "capacity": 70,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 1.00€, 1 Woche: 5.00€, 1 Monat (am Automaten): 19.00€, 1 Monat Dauerparken (mind. 3 Monate): 19.00€, 1 Monat Dauerparken (fester Stellplatz): 32.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.181252,
+          50.669584
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100040",
-        "name": "Parkplatz Hauptbahnhof Nord",
+        "name": "Braunschweig Hbf Parkplatz Nord",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100040",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Braunschweig\n38102\nWilly-Brandt-Platz",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100040/prognoses",
+        "address": "Willy-Brandt-Platz, 38102 Braunschweig",
         "capacity": 185,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.20€, 1 Tag: 15.00€, 1 Tag rabattiert: 12.50€, 1 Monat Dauerparken (mind. 3 Monate): 110.00€, 1 Monat Dauerparken (fester Stellplatz): 160.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -144,13 +1089,86 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100041",
+        "name": "Braunschweig Hbf Parkplatz Ackerstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100041",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100041/prognoses",
+        "address": "Ackerstraße, 38102 Braunschweig",
+        "capacity": 385,
+        "capacity_disabled": 6,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 9.00€, 1 Woche: 45.00€, 1 Monat (am Automaten): 73.00€, 1 Monat Dauerparken (mind. 3 Monate): 69.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.542638,
+          52.252212
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100042",
+        "name": "Braunschweig Hbf Parkplatz West",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100042",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100042/prognoses",
+        "address": "Berliner Platz 1, 38102 Braunschweig",
+        "capacity": 72,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 9.00€, 1 Woche: 45.00€, 1 Monat (am Automaten): 73.00€, 1 Monat Dauerparken (mind. 3 Monate): 69.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.538076,
+          52.251725
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100043",
-        "name": "Hochgarage am Bahnhof",
+        "name": "Bremen Hbf Hochgarage am Bahnhof",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100043",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Bremen\n28195\nRembertiring 6",
-        "capacity": 289,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100043/prognoses",
+        "address": "Rembertiring 6, 28195 Bremen",
+        "capacity": 287,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "Mo-Fr 06:00-22:00, Sa 07:00-22:00",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 4.00€, 1 Monat Dauerparken (mind. 3 Monate): 97.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -164,13 +1182,210 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100044",
+        "name": "Vorfahrt Bahnhof Bremen-Vegesack",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100044",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100044/prognoses",
+        "address": "Vegesacker Bahnhofsplatz, 28757 Bremen",
+        "capacity": 7,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Tag",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 4.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.628907,
+          53.169791
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100045",
+        "name": "Parkplatz Bahnhof Bremen-Vegesack",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100045",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100045/prognoses",
+        "address": "Vegesacker Bahnhofsplatz, 28758 Bremen",
+        "capacity": 103,
+        "capacity_disabled": 3,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 2.50€, 1 Woche: 12.50€, 1 Monat (am Automaten): 28.00€, 1 Monat Dauerparken (mind. 3 Monate): 28.00€, 1 Monat Dauerparken (fester Stellplatz): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.6298,
+          53.170282
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100046",
+        "name": "Vorfahrt Bahnhof Bruchsal",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100046",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100046/prognoses",
+        "address": "Bahnhofsplatz, 76646 Bruchsal",
+        "capacity": 20,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.10€, 1 Stunde: 2.20€, 1 Tag: 11.00€, 1 Woche: 55.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.590533,
+          49.124223
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100047",
+        "name": "Parkplatz Bruchsal Bahnhofsplatz rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100047",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100047/prognoses",
+        "address": "Bahnhofsplatz, 76646 Bruchsal",
+        "capacity": 45,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.80€, 1 Tag: 8.00€, 1 Woche: 32.00€, 1 Monat Dauerparken (mind. 3 Monate): 80.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.591019,
+          49.125335
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100048",
+        "name": "Parkplatz Bruchsal Bahnhofsplatz links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100048",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100048/prognoses",
+        "address": "Bahnhofsplatz, 76646 Bruchsal",
+        "capacity": 90,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.80€, 1 Tag: 8.00€, 1 Woche: 32.00€, 1 Monat (am Automaten): 70.00€, 1 Monat Dauerparken (mind. 3 Monate): 70.00€, 1 Monat Dauerparken (fester Stellplatz): 165.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.590012,
+          49.12341
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100049",
+        "name": "Parkplatz Bahnhof Bruchsal Nord",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100049",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100049/prognoses",
+        "address": "Bahnhofstraße, 76646 Bruchsal",
+        "capacity": 20,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.80€, 1 Tag: 8.00€, 1 Woche: 32.00€, 1 Monat (am Automaten): 70.00€, 1 Monat Dauerparken (mind. 3 Monate): 70.00€, 1 Monat Dauerparken (fester Stellplatz): 140.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.5911,
+          49.126212
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100050",
-        "name": "Parkplatz Bahnhof Coburg Vorderseite",
+        "name": "Parkplatz Bahnhof Coburg Lossaustraße",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100050",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Coburg\n96450\nLossaustraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100050/prognoses",
+        "address": "Lossaustraße, 96450 Coburg",
         "capacity": 56,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.20€, 1 Tag: 6.00€, 1 Woche: 30.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -184,13 +1399,117 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100051",
+        "name": "Parkplatz Bahnhof Coswig",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100051",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100051/prognoses",
+        "address": "Sachsenstraße, 01640 Coswig in Sachsen",
+        "capacity": 34,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.50€, 1 Stunde: 1.00€, 1 Tag: 3.00€, 1 Monat (am Automaten): 11.00€, 1 Monat Dauerparken (mind. 3 Monate): 11.00€, 1 Monat Dauerparken (fester Stellplatz): 20.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.58021,
+          51.123028
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100052",
+        "name": "Parkplatz Bahnhof Crailsheim",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100052",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100052/prognoses",
+        "address": "Zum Bahnhof, 74565 Crailsheim",
+        "capacity": 78,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 8 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 4.40€, 1 Woche: 22.00€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€, 1 Monat Dauerparken (fester Stellplatz): 70.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.064123,
+          49.139566
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100053",
+        "name": "Parkplatz Bahnhof Crailsheim Rückseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100053",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100053/prognoses",
+        "address": "Worthingtonstraße, B290, 74564 Crailsheim",
+        "capacity": 73,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 3.00€, 1 Woche: 15.00€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.066097,
+          49.137868
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100054",
         "name": "Parkplatz Bahnhof Düren Ludwig-Erhard-Platz",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100054",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Düren\n52351\nLudwig-Erhard-Platz\nüber Eisenbahnstraße\nvia Eisenbahnstraße",
-        "capacity": 187,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100054/prognoses",
+        "address": "Ludwig-Erhard-Platz, 52351 Düren",
+        "capacity": 197,
+        "capacity_disabled": 4,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.40€, 1 Tag: 4.80€, 1 Woche: 24.00€, 1 Monat (am Automaten): 55.00€, 1 Monat Dauerparken (mind. 3 Monate): 55.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -204,13 +1523,117 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100055",
+        "name": "Parkplatz Bahnhof Düren Eisenbahnstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100055",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100055/prognoses",
+        "address": "Eisenbahnstraße, 52349 Düren",
+        "capacity": 165,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.70€, 1 Tag: 3.30€, 1 Woche: 16.50€, 1 Monat (am Automaten): 35.00€, 1 Monat Dauerparken (mind. 3 Monate): 35.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.481233,
+          50.810312
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100056",
+        "name": "Vorplatz Düsseldorf Hbf links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100056",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100056/prognoses",
+        "address": "Konrad-Adenauer-Platz 13-14, 40227 Düsseldorf",
+        "capacity": 31,
+        "capacity_disabled": 0,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 2.30€, 1 Stunde: 4.60€, 1 Tag: 29.00€, 1 Woche: 145.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.793745,
+          51.221361
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100057",
+        "name": "Vorplatz Düsseldorf Hbf Uhrenturm",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100057",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100057/prognoses",
+        "address": "Konrad-Adenauer-Platz 14, 40227 Düsseldorf",
+        "capacity": 32,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 2.30€, 1 Stunde: 4.60€, 1 Tag: 29.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.791614,
+          51.219731
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100058",
         "name": "Parkhaus Düsseldorf Hauptbahnhof",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100058",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Düsseldorf\n40227\nWilli-Becker-Allee/Ludwig-Erhard-Allee",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100058/prognoses",
+        "address": "Willi-Becker-Allee/Ludwig-Erhard-Allee, 40227 Düsseldorf",
         "capacity": 1685,
+        "capacity_disabled": 12,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 3.00€, 1 Tag: 22.00€, 1 Tag rabattiert: 19.00€, 1 Woche: 80.00€, 1 Monat Dauerparken (mind. 3 Monate): 110.00€, 1 Monat Dauerparken (fester Stellplatz): 150.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -224,13 +1647,179 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100059",
+        "name": "Parkplatz Bahnhof Delmenhorst rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100059",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100059/prognoses",
+        "address": "Wittekindstraße 2, 27749 Delmenhorst",
+        "capacity": 24,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 11 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.50€, 1 Woche: 17.50€, 1 Monat (am Automaten): 35.00€, 1 Monat Dauerparken (mind. 3 Monate): 35.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.632163,
+          53.052769
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100060",
+        "name": "Parkplatz Bahnhof Dillingen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100060",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100060/prognoses",
+        "address": "Berkheimstraße, 66763 Dillingen an der Saar",
+        "capacity": 80,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 1.50€, 1 Woche: 6.00€, 1 Monat (am Automaten): 15.00€, 1 Monat Dauerparken (mind. 3 Monate): 15.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.722298,
+          49.353183
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100061",
+        "name": "Parkplatz Dortmund Hbf Nord Treibstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100061",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100061/prognoses",
+        "address": "Treibstraße, 44137 Dortmund",
+        "capacity": 542,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Der Zugang zum Bahnhof ist nicht barrierefrei. Ein Fahrstuhl befindet sich zurzeit im Bau.",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.20€, 1 Tag: 4.00€, 1 Woche: 20.00€, 1 Monat (am Automaten): 65.00€, 1 Monat Dauerparken (mind. 3 Monate): 65.00€, 1 Monat Dauerparken (fester Stellplatz): 110.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.457624,
+          51.518723
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100062",
+        "name": "Parkplatz Dortmund Hbf Königswall rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100062",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100062/prognoses",
+        "address": "Königswall 13-15, 44137 Dortmund",
+        "capacity": 35,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 9.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.461422,
+          51.517324
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100063",
+        "name": "Dresden Hbf Tiefgarage Wiener Platz",
+        "type": "underground",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100063/prognoses",
+        "address": "Wiener Platz, 01069 Dresden",
+        "capacity": 770,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "",
+        "operator": "Dürr Liegenschaften GmbH & Co. KG",
+        "description": "Ein- und Ausfahrt mittels Kreditkarte möglich.",
+        "has_fee": true,
+        "fee_description": "1 Tag: 16.00€, 1 Tag rabattiert: 12.00€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.730904,
+          51.0423
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100066",
         "name": "Parkhaus Duisburg Hbf / UCI",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100066",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Duisburg\n47057\nNeudorfer Straße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100066/prognoses",
+        "address": "Neudorfer Straße, 47057 Duisburg",
         "capacity": 398,
+        "capacity_disabled": 8,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 12.00€, 1 Tag rabattiert: 8.00€, 1 Monat Dauerparken (mind. 3 Monate): 140.00€, 1 Monat Dauerparken (fester Stellplatz): 200.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -244,13 +1833,148 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100069",
+        "name": "Parkplatz Bahnhof Eisenach",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100069",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100069/prognoses",
+        "address": "Bahnhofstraße 35 (B19), 99817 Eisenach",
+        "capacity": 63,
+        "capacity_disabled": 3,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 5.50€, 1 Woche: 27.50€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 70.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.332728,
+          50.975939
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100070",
+        "name": "Parkplatz Bahnhof Elmshorn Kleiststraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100070",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100070/prognoses",
+        "address": "Kleiststraße 1-15, 25335 Elmshorn",
+        "capacity": 150,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.30€, 1 Tag: 3.00€, 1 Woche: 15.00€, 1 Monat (am Automaten): 35.00€, 1 Monat Dauerparken (mind. 3 Monate): 35.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.659233,
+          53.757109
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100071",
+        "name": "Parkplatz Bahnhof Elmshorn Schulstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100071",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100071/prognoses",
+        "address": "Schulstraße, 25335 Elmshorn",
+        "capacity": 19,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.30€, 1 Tag: 5.30€, 1 Woche: 26.50€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.658395,
+          53.75562
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100072",
+        "name": "Parkplatz Bahnhof Erlangen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100072",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100072/prognoses",
+        "address": "Friedrich-List-Straße, 91052 Erlangen",
+        "capacity": 32,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.10€, 1 Stunde: 2.20€, 1 Tag: 7.50€, 1 Woche: 37.50€, 1 Monat (am Automaten): 100.00€, 1 Monat Dauerparken (mind. 3 Monate): 100.00€, 1 Monat Dauerparken (fester Stellplatz): 200.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.001674,
+          49.594404
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100073",
         "name": "Parkhaus Essen Hauptbahnhof",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100073",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Essen\n45127\nFreiheit 5",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100073/prognoses",
+        "address": "Freiheit 5, 45127 Essen",
         "capacity": 742,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark International Parking GmbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 18.00€, 1 Tag rabattiert: 15.00€, 1 Monat Dauerparken (mind. 3 Monate): 100.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -264,13 +1988,241 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100074",
+        "name": "Essen Hbf Vorplatz Nord",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100074",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100074/prognoses",
+        "address": "Am Hauptbahnhof 5, 45127 Essen",
+        "capacity": 33,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.50€, 1 Stunde: 3.00€, 1 Tag: 22.00€, 1 Woche: 154.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.014919,
+          51.452121
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100075",
+        "name": "Parkplatz Essen Hbf Hachestraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100075",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100075/prognoses",
+        "address": "Hachestraße, 45127 Essen",
+        "capacity": 26,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 12.00€, 1 Woche: 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.010534,
+          51.451639
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100076",
+        "name": "Parkplatz Bahnhof Euskirchen Oststraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100076",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100076/prognoses",
+        "address": "Oststraße, 53879 Euskirchen",
+        "capacity": 25,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.70€, 1 Tag: 15.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.793448,
+          50.658478
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100077",
+        "name": "Parkplatz Bahnhof Fürstenfeldbruck",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100077",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100077/prognoses",
+        "address": "Oskar-von-Miller-Straße, 82256 Fürstenfeldbruck",
+        "capacity": 387,
+        "capacity_disabled": 3,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.70€, 1 Tag: 2.00€, 1 Woche: 8.00€, 1 Monat (am Automaten): 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 17.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.261719,
+          48.172913
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100078",
+        "name": "Parkplatz Forchheim Bahnhofsplatz rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100078",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100078/prognoses",
+        "address": "Bahnhofsplatz, 91301 Forchheim in Oberfranken",
+        "capacity": 12,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 3.00€, 1 Woche: 12.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€, 1 Monat Dauerparken (fester Stellplatz): 58.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.069613,
+          49.716201
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100079",
+        "name": "Vorplatz Frankenthal Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100079",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100079/prognoses",
+        "address": "Eisenbahnstraße, 67228 Frankenthal",
+        "capacity": 25,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 5.50€, 1 Woche: 27.50€, 1 Monat Dauerparken (mind. 3 Monate): 80.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.350276,
+          49.535623
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100080",
+        "name": "Parkplatz Frankenthal Hbf rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100080",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100080/prognoses",
+        "address": "Eisenbahnstraße, 67227 Frankenthal",
+        "capacity": 11,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.40€, 1 Tag: 4.50€, 1 Woche: 18.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.350094,
+          49.536659
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100081",
-        "name": "Tiefgarage Hauptbahnhof Nord",
+        "name": "Frankfurt (Main) Tiefgarage Hbf Nord",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100081",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Frankfurt am Main\n60329\nPoststraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100081/prognoses",
+        "address": "Poststraße, 60329 Frankfurt am Main",
         "capacity": 365,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Die Garage ist nicht barrierefrei. Fahrstuhl bis auf Weiteres außer Betrieb.",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 3.50€, 1 Tag: 33.00€, 1 Tag rabattiert: 28.00€, 1 Monat Dauerparken (mind. 3 Monate): 290.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -285,12 +2237,23 @@
       "type": "Feature",
       "properties": {
         "id": "db-100083",
-        "name": "Hauptbahnhof Vorfahrt II",
+        "name": "Frankfurt (Main) Hbf Vorfahrt II",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100083",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Frankfurt am Main\n60329\nPoststraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100083/prognoses",
+        "address": "Poststraße, 60329 Frankfurt am Main",
         "capacity": 18,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 4.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -304,20 +2267,124 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "db-100084",
-        "name": "Frankfurt (Main) Hbf Bustasche",
+        "id": "db-100085",
+        "name": "Frankfurt (Main) Hbf Parkplatz Gleis 26",
         "type": "lot",
-        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100084",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Frankfurt am Main\n60329\nAm Hauptbahnhof",
-        "capacity": 43,
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100085",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100085/prognoses",
+        "address": "Poststraße, 60329 Frankfurt am Main",
+        "capacity": 19,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 4.00€, 1 Tag: 35.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          8.66479,
-          50.107129
+          8.660092,
+          50.107071
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100086",
+        "name": "Parkplatz Bahnhof Frankfurt (Main) West",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100086",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100086/prognoses",
+        "address": "Kasseler Straße, 60486 Frankfurt am Main",
+        "capacity": 90,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.80€, 1 Tag: 6.00€, 1 Woche: 30.00€, 1 Monat (am Automaten): 65.00€, 1 Monat Dauerparken (mind. 3 Monate): 65.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.639006,
+          50.119698
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100087",
+        "name": "Parkplatz Bahnhof Höchst Dalbergstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100087",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100087/prognoses",
+        "address": "Dalbergstraße, 65929 Frankfurt am Main",
+        "capacity": 43,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.50€, 1 Stunde: 3.00€, 1 Tag: 6.50€, 1 Woche: 32.50€, 1 Monat Dauerparken (mind. 3 Monate): 120.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.543826,
+          50.102158
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100088",
+        "name": "Parkplatz Bahnhof Höchst Farbwerke",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100088",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100088/prognoses",
+        "address": "Hoechster-Farben-Straße, 65931 Frankfurt am Main",
+        "capacity": 82,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 3.50€, 1 Woche: 17.50€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.527036,
+          50.097678
         ]
       }
     },
@@ -325,12 +2392,23 @@
       "type": "Feature",
       "properties": {
         "id": "db-100090",
-        "name": "Tiefgarage am Bahnhof",
+        "name": "Freiburg (Breisgau) Hbf Tiefgarage am Bahnhof",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100090",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Freiburg im Breisgau\n79098\nBismarckallee",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100090/prognoses",
+        "address": "Bismarckallee, 79098 Freiburg im Breisgau",
         "capacity": 278,
+        "capacity_disabled": 10,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "05:30-01:00",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Parken direkt am Gleis.",
+        "has_fee": true,
+        "fee_description": "20 Minuten: 0.60€, 1 Stunde: 2.50€, 1 Tag: 20.00€, 1 Tag rabattiert: 15.00€, 1 Monat Dauerparken (mind. 3 Monate): 195.00€, 1 Monat Dauerparken (fester Stellplatz): 300.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -344,13 +2422,272 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100091",
+        "name": "Parkplatz Freiburg Hbf Wentzingerstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100091",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100091/prognoses",
+        "address": "Wentzingerstraße, 79106 Freiburg im Breisgau",
+        "capacity": 125,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.40€, 1 Tag: 14.00€, 1 Woche: 70.00€, 1 Monat Dauerparken (mind. 3 Monate): 175.00€, 1 Monat Dauerparken (fester Stellplatz): 250.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.839455,
+          47.996924
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100093",
+        "name": "Parkplatz Bahnhof Friedberg Vorfahrt",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100093",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100093/prognoses",
+        "address": "Hanauer Straße, 61169 Friedberg in Hessen",
+        "capacity": 10,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.20€, 1 Tag: 7.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.760571,
+          50.332411
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100094",
+        "name": "Parkplatz Bahnhof Friedberg links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100094",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100094/prognoses",
+        "address": "Hanauer Straße, 61169 Friedberg in Hessen",
+        "capacity": 72,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 9 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.20€, 1 Tag: 7.00€, 1 Woche: 49.00€, 1 Monat (am Automaten): 67.00€, 1 Monat Dauerparken (mind. 3 Monate): 67.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.76013,
+          50.333159
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100096",
+        "name": "Parkplatz Bahnhof Fulda links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100096",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100096/prognoses",
+        "address": "Kurfürstenstraße, 36037 Fulda",
+        "capacity": 15,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.20€, 1 Stunde: 2.40€, 1 Tag: 11.00€, 1 Woche: 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.683199,
+          50.554729
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100097",
+        "name": "Parkplatz Bahnhof Fulda rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100097",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100097/prognoses",
+        "address": "Am Bahnhof, 36037 Fulda",
+        "capacity": 13,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.20€, 1 Stunde: 2.40€, 1 Tag: 11.00€, 1 Woche: 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.684362,
+          50.554043
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100098",
+        "name": "Parkplatz Bahnhof Fulda Viehrampe",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100098",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100098/prognoses",
+        "address": "Kurfürstenstraße, 36037 Fulda",
+        "capacity": 45,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 85.00€, 1 Monat Dauerparken (fester Stellplatz): 125.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.682424,
+          50.555205
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100099",
+        "name": "Parkplatz Bahnhof Garmisch-Partenkirchen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100099",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100099/prognoses",
+        "address": "Bahnhofstraße, 82467 Garmisch-Partenkirchen",
+        "capacity": 87,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 8 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 6.50€, 1 Woche: 32.50€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 45.00€, 1 Monat Dauerparken (fester Stellplatz): 100.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.098251,
+          47.491699
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100101",
+        "name": "Parkplatz Bahnhof Göppingen Davidstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100101",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100101/prognoses",
+        "address": "Schützenstraße/Davidstraße, 73033 Göppingen",
+        "capacity": 55,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 9.00€, 1 Woche: 45.00€, 1 Monat (am Automaten): 75.00€, 1 Monat Dauerparken (mind. 3 Monate): 75.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.65384,
+          48.699943
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100102",
         "name": "Parkplatz Bahnhof Göttingen Bahnhofsallee",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100102",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Göttingen\n37081\nBahnhofsallee 2",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100102/prognoses",
+        "address": "Bahnhofsallee 2, 37081 Göttingen",
         "capacity": 107,
+        "capacity_disabled": 6,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.20€, 1 Tag: 18.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -368,9 +2705,20 @@
         "name": "Parkhaus Bahnhof Göttingen",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100103",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Göttingen\n37081\nBahnhofsallee 2",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100103/prognoses",
+        "address": "Bahnhofsallee 2, 37081 Göttingen",
         "capacity": 561,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.20€, 1 Tag: 16.00€, 1 Tag rabattiert: 13.50€, 1 Woche: 50.00€, 1 Monat Dauerparken (mind. 3 Monate): 110.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -384,13 +2732,210 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100104",
+        "name": "Parkplatz Bahnhof Geislingen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100104",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100104/prognoses",
+        "address": "Bahnhofstraße, 73312 Geislingen an der Steige",
+        "capacity": 50,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 5.20€, 1 Woche: 20.80€, 1 Monat (am Automaten): 47.00€, 1 Monat Dauerparken (mind. 3 Monate): 47.00€, 1 Monat Dauerparken (fester Stellplatz): 90.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.841341,
+          48.619083
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100105",
+        "name": "Parkplatz Bahnhof Geislingen Katzenloch",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100105",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100105/prognoses",
+        "address": "Weilerstraße, 73312 Geislingen an der Steige",
+        "capacity": 48,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 3.00€, 1 Woche: 12.00€, 1 Monat (am Automaten): 25.00€, 1 Monat Dauerparken (mind. 3 Monate): 25.00€, 1 Monat Dauerparken (fester Stellplatz): 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.843577,
+          48.62103
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100107",
+        "name": "Parkhaus Bahnhof Gelnhausen",
+        "type": "garage",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100107",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100107/prognoses",
+        "address": "Bahnhofstraße 8, 63571 Gelnhausen",
+        "capacity": 321,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "... für Navinutzer: Achtung. Gleiche Adresse am Bahnhof Hailer-Meerholz (ebenfalls Gelnhausen).",
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.50€, 1 Stunde: 1.00€, 1 Tag: 3.90€, 1 Woche: 19.50€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 42.00€, 1 Monat Dauerparken (fester Stellplatz): 65.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.190164,
+          50.196849
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100108",
+        "name": "Parkplatz Bahnhof Gemünden",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100108",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100108/prognoses",
+        "address": "Bahnhofstraße, 97737 Gemünden am Main",
+        "capacity": 21,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 1.50€, 1 Woche: 7.50€, 1 Monat (am Automaten): 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.701151,
+          50.049604
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100109",
+        "name": "Parkplatz Gera Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100109",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100109/prognoses",
+        "address": "Bahnhofstraße/Franz-Mehring-Straße, 07545 Gera",
+        "capacity": 130,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 11 Tage oder 4-Wochen-Parkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 3.80€, 1 Woche: 19.00€, 1 Monat Dauerparken (mind. 3 Monate): 48.00€, 1 Monat Dauerparken (fester Stellplatz): 70.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.078861,
+          50.884647
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100110",
+        "name": "Parkplatz Bahnhof Gera Süd",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100110",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100110/prognoses",
+        "address": "Sachsenplatz/Erfurtstraße, 07545 Gera",
+        "capacity": 75,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 1.70€, 1 Woche: 8.50€, 1 Monat Dauerparken (mind. 3 Monate): 23.00€, 1 Monat Dauerparken (fester Stellplatz): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.079624,
+          50.869704
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100111",
-        "name": "Parkhaus am Bahnhof",
+        "name": "Parkhaus am Bahnhof Gießen",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100111",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Gießen\n35390\nBahnhofstraße / An der alten Post",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100111/prognoses",
+        "address": "Bahnhofstraße / An der alten Post, 35390 Gießen",
         "capacity": 247,
+        "capacity_disabled": 8,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.70€, 1 Tag: 6.50€, 1 Tag rabattiert: 5.00€, 1 Monat Dauerparken (mind. 3 Monate): 95.00€, 1 Monat Dauerparken (fester Stellplatz): 140.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -404,20 +2949,31 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "db-100114",
-        "name": "Tiefgarage Charlottencenter",
-        "type": "underground",
-        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100114",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Halle an der Saale\n06108\nDorotheenstraße",
-        "capacity": 472,
+        "id": "db-100113",
+        "name": "Parkplatz Halle Hbf Ernst-Kamieth-Straße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100113",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100113/prognoses",
+        "address": "Ernst-Kamieth-Straße, 06112 Halle an der Saale",
+        "capacity": 75,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 7.00€, 1 Woche: 35.00€, 1 Monat Dauerparken (mind. 3 Monate): 100.00€, 1 Monat Dauerparken (fester Stellplatz): 160.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          11.980912,
-          51.480373
+          11.985823,
+          51.47668
         ]
       }
     },
@@ -428,9 +2984,20 @@
         "name": "Parkhaus Hauptbahnhof Centrum Hühnerposten",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100115",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Hamburg\n20097\nHühnerposten",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100115/prognoses",
+        "address": "Hühnerposten, 20097 Hamburg",
         "capacity": 427,
+        "capacity_disabled": 7,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "04:00-22:00",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Noch schneller am Zug: Neue Treppenzugänge von der Steindammbrücke!",
+        "has_fee": true,
+        "fee_description": "1 Tag: 17.00€, 1 Tag rabattiert: 14.00€, 1 Monat Dauerparken (mind. 3 Monate): 230.00€, 1 Monat Dauerparken (fester Stellplatz): 330.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -444,13 +3011,334 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100116",
+        "name": "Parkplatz Hühnerposten",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100116",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100116/prognoses",
+        "address": "Hühnerposten 1-2, 20097 Hamburg",
+        "capacity": 16,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 3.00€, 1 Tag: 19.00€, 1 Woche: 133.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.008548,
+          53.549487
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100118",
+        "name": "Parkplatz Bahnhof Hamburg-Harburg",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100118",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100118/prognoses",
+        "address": "Hannoversche Straße, 21079 Hamburg",
+        "capacity": 41,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.30€, 1 Stunde: 2.60€, 1 Tag: 10.00€, 1 Woche: 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.990306,
+          53.455918
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100120",
+        "name": "Vorplatz Hanau Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100120",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100120/prognoses",
+        "address": "Am Hauptbahnhof, 63451 Hanau",
+        "capacity": 20,
+        "capacity_disabled": 0,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.40€, 1 Stunde: 2.80€, 1 Tag: 7.00€, 1 Woche: 35.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.929814,
+          50.121738
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100122",
+        "name": "Parkplatz Hanau Hbf Güterbahnhofstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100122",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100122/prognoses",
+        "address": "Güterbahnhofstraße, 63450 Hanau",
+        "capacity": 110,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 4.80€, 1 Woche: 24.00€, 1 Monat (am Automaten): 65.00€, 1 Monat Dauerparken (mind. 3 Monate): 55.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.928447,
+          50.122254
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100123",
+        "name": "Parkplatz Hanau Hbf Vorderseite rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100123",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100123/prognoses",
+        "address": "Am Hauptbahnhof, 63450 Hanau",
+        "capacity": 180,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 4.80€, 1 Woche: 24.00€, 1 Monat (am Automaten): 65.00€, 1 Monat Dauerparken (mind. 3 Monate): 55.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.92967,
+          50.122427
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100124",
+        "name": "Parkplatz Hanau Hbf Vorderseite links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100124",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100124/prognoses",
+        "address": "Boschstraße, 63450 Hanau",
+        "capacity": 156,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 4.80€, 1 Woche: 24.00€, 1 Monat (am Automaten): 65.00€, 1 Monat Dauerparken (mind. 3 Monate): 55.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.932183,
+          50.121033
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100125",
+        "name": "Hannover Hbf Ernst-August-Platz rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100125",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100125/prognoses",
+        "address": "Fernroderstraße, 30159 Hannover",
+        "capacity": 13,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 2.50€, 1 Stunde: 5.00€, 1 Tag: 20.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.741477,
+          52.375911
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100126",
+        "name": "Hannover Hbf Ernst-August-Platz links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100126",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100126/prognoses",
+        "address": "Kurt-Schumacher-Straße, 30159 Hannover",
+        "capacity": 14,
+        "capacity_disabled": 3,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 2.50€, 1 Stunde: 5.00€, 1 Tag: 20.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.739688,
+          52.376689
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100127",
+        "name": "Parkplatz Hannover Hbf Fernroder Straße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100127",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100127/prognoses",
+        "address": "Fernroder Straße, 30159 Hannover",
+        "capacity": 7,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Tag",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.50€, 1 Stunde: 3.00€, 1 Tag: 10.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.743777,
+          52.377008
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100129",
+        "name": "Parkplatz Hannover Hbf Augustenstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100129",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100129/prognoses",
+        "address": "Augustenstraße, 30161 Hannover",
+        "capacity": 140,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.40€, 1 Tag: 16.00€, 1 Woche: 40.00€, 1 Monat (am Automaten): 85.00€, 1 Monat Dauerparken (mind. 3 Monate): 85.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.745623,
+          52.375787
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100130",
         "name": "Tiefgarage Hauptbahnhof Augustenstraße",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100130",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Hannover\n30161\nAugustenstraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100130/prognoses",
+        "address": "Augustenstraße, 30161 Hannover",
         "capacity": 145,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "Mo-Fr 06:00-19:00",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.40€, 1 Tag: 8.00€, 1 Woche: 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 85.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -464,13 +3352,737 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100134",
+        "name": "Parkplatz Heilbronn Hauptbahnhof",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100134",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100134/prognoses",
+        "address": "Bahnhofstraße 11, 74072 Heilbronn",
+        "capacity": 456,
+        "capacity_disabled": 3,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 9 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.70€, 1 Tag: 11.00€, 1 Woche: 55.00€, 1 Monat (am Automaten): 85.00€, 1 Monat Dauerparken (mind. 3 Monate): 85.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.212226,
+          49.143582
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100136",
+        "name": "Parkplatz Bahnhof Herrenberg",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100136",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100136/prognoses",
+        "address": "Bahnhofstraße, 71083 Herrenberg",
+        "capacity": 122,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 3.50€, 1 Woche: 17.50€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.861743,
+          48.593261
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100137",
+        "name": "Bahnhof Hersbruck Kurzzeitparkplatz",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100137",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100137/prognoses",
+        "address": "Bahngelände, 91217 Hersbruck",
+        "capacity": 14,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 3.00€, 1 Woche: 15.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.425012,
+          49.509909
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100138",
+        "name": "Bahnhof Hersbruck Vorderseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100138",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100138/prognoses",
+        "address": "Bahngelände, 91217 Hersbruck",
+        "capacity": 125,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 1.90€, 1 Woche: 7.60€, 1 Monat (am Automaten): 19.00€, 1 Monat Dauerparken (mind. 3 Monate): 19.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.423041,
+          49.509658
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100139",
+        "name": "Bahnhof Hersbruck Vorderseite links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100139",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100139/prognoses",
+        "address": "Bahngelände, 91217 Hersbruck",
+        "capacity": 60,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 1.90€, 1 Woche: 7.60€, 1 Monat (am Automaten): 19.00€, 1 Monat Dauerparken (mind. 3 Monate): 19.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.420634,
+          49.509274
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100140",
+        "name": "Hildesheim Hbf Rückseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100140",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100140/prognoses",
+        "address": "Altes Dorf, 31134 Hildesheim",
+        "capacity": 24,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 6.00€, 1 Woche: 24.00€, 1 Monat (am Automaten): 55.00€, 1 Monat Dauerparken (mind. 3 Monate): 55.00€, 1 Monat Dauerparken (fester Stellplatz): 120.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.952323,
+          52.160717
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100141",
+        "name": "Hildesheim Hbf Bischof-Janssen-Straße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100141",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100141/prognoses",
+        "address": "Bischof-Janssen-Straße, 31134 Hildesheim",
+        "capacity": 90,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.40€, 1 Tag: 4.50€, 1 Woche: 22.50€, 1 Monat (am Automaten): 55.00€, 1 Monat Dauerparken (mind. 3 Monate): 55.00€, 1 Monat Dauerparken (fester Stellplatz): 120.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.949124,
+          52.15819
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100142",
+        "name": "Hildesheim Hbf Parkgarage Rose",
+        "type": "garage",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100142/prognoses",
+        "address": "Bischof-Janssen-Straße, 31134 Hildesheim",
+        "capacity": 476,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "",
+        "operator": "MPU Fix GmbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 6.00€, 1 Tag rabattiert: 4.00€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.949855,
+          52.158108
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100143",
+        "name": "Vorfahrt Hof Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100143",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100143/prognoses",
+        "address": "Bahnhofsplatz, 95028 Hof",
+        "capacity": 23,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 4.00€, 1 Woche: 16.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.923359,
+          50.308478
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100144",
+        "name": "Parkplatz Hof Hbf Rondell links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100144",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100144/prognoses",
+        "address": "Bahnhofsplatz 14, 95028 Hof",
+        "capacity": 30,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 4.00€, 1 Woche: 16.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€, 1 Monat Dauerparken (fester Stellplatz): 90.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.92425,
+          50.30801
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100145",
+        "name": "Parkplatz Hof Hbf Rondell rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100145",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100145/prognoses",
+        "address": "Bahnhofsplatz, 95028 Hof",
+        "capacity": 16,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 4.00€, 1 Woche: 16.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.922821,
+          50.308513
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100146",
+        "name": "Bahnhof Holzkirchen Parktaschen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100146",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100146/prognoses",
+        "address": "Bahnhofplatz, 83607 Holzkirchen",
+        "capacity": 8,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Stunde",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.697462,
+          47.883153
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100147",
+        "name": "Bahnhof Holzkirchen Bahnhofplatz",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100147",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100147/prognoses",
+        "address": "Bahnhofplatz, 83607 Holzkirchen",
+        "capacity": 93,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 1.50€, 1 Woche: 8.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.696217,
+          47.884382
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100148",
+        "name": "Bahnhof Holzkirchen Bahnhofplatz rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100148",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100148/prognoses",
+        "address": "Bahnhofplatz, 83607 Holzkirchen",
+        "capacity": 97,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 1.50€, 1 Woche: 8.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.697174,
+          47.883515
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100149",
+        "name": "Bahnhof Holzkirchen Bahnhofplatz links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100149",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100149/prognoses",
+        "address": "Bahnhofplatz, 83607 Holzkirchen",
+        "capacity": 40,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 1.50€, 1 Woche: 8.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.695502,
+          47.884899
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100150",
+        "name": "Bahnhof Holzkirchen Dauerparkplatz Otterfinger Weg",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100150",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100150/prognoses",
+        "address": "Bahnhofplatz / Otterfinger Weg, 83607 Holzkirchen",
+        "capacity": 71,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 1.50€, 1 Woche: 8.00€, 1 Monat Dauerparken (mind. 3 Monate): 25.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.695207,
+          47.885524
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100151",
+        "name": "Bahnhof Holzkirchen Dauerparkplatz Am Ladehof",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100151",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100151/prognoses",
+        "address": "Am Ladehof, 83607 Holzkirchen",
+        "capacity": 28,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 25.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.695901,
+          47.886298
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100152",
+        "name": "Bahnhof Holzkirchen Erlkamer Str. Ladeh.",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100152",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100152/prognoses",
+        "address": "Am Ladehof / Erlkamer Straße, 83607 Holzkirchen",
+        "capacity": 89,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 1.50€, 1 Woche: 8.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.695998,
+          47.886417
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100153",
+        "name": "Parkplatz Homburg (Saar) Hbf Bahnhofspl.",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100153",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100153/prognoses",
+        "address": "Bahnhofsplatz, 66424 Homburg an der Saar",
+        "capacity": 46,
+        "capacity_disabled": 4,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 8 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 6.50€, 1 Woche: 32.50€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 45.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.33748,
+          49.327386
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100154",
+        "name": "Parkplatz Homburg (Saar) Hbf rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100154",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100154/prognoses",
+        "address": "Bahnhofsplatz, 66424 Homburg an der Saar",
+        "capacity": 34,
+        "capacity_disabled": 0,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 9 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 5.00€, 1 Woche: 25.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.338113,
+          49.328012
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100155",
+        "name": "Parkplatz Homburg (Saar) Hbf links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100155",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100155/prognoses",
+        "address": "Güterbahnhofstraße, 66424 Homburg an der Saar",
+        "capacity": 91,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 9 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 5.00€, 1 Woche: 25.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€, 1 Monat Dauerparken (fester Stellplatz): 80.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.336214,
+          49.326868
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100156",
+        "name": "Parkplatz Bahnhof Husum",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100156",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100156/prognoses",
+        "address": "Poggenburgstraße, 25813 Husum",
+        "capacity": 42,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 7.80€, 1 Woche: 35.00€, 1 Monat (am Automaten): 60.00€, 1 Monat Dauerparken (mind. 3 Monate): 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.053282,
+          54.472588
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100157",
+        "name": "Parkplatz Kaiserslautern Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100157",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100157/prognoses",
+        "address": "Zollamtstraße, 67663 Kaiserslautern",
+        "capacity": 39,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Tag",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 8.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.769379,
+          49.435537
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100158",
-        "name": "Park+Ride-Parkhaus Hauptbahnhof",
+        "name": "Park+Ride-Parkhaus Kaiserslautern Hbf",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100158",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Kaiserslautern\n67663\nZollamtstraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100158/prognoses",
+        "address": "Zollamtstraße, 67663 Kaiserslautern",
         "capacity": 359,
+        "capacity_disabled": 4,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 9.00€, 1 Tag rabattiert: 6.00€, 1 Monat Dauerparken (mind. 3 Monate): 49.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -484,13 +4096,241 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100160",
+        "name": "Vorplatz Karlsruhe Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100160",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100160/prognoses",
+        "address": "Bahnhofsplatz, 76137 Karlsruhe",
+        "capacity": 30,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.40€, 1 Stunde: 2.80€, 1 Tag: 15.00€, 1 Woche: 75.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.401718,
+          48.994524
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100162",
+        "name": "Parkplatz Karlsruhe Hbf Schwarzwaldstr.",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100162",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100162/prognoses",
+        "address": "Schwarzwaldstraße / Hinterm Hauptbahnhof, 76137 Karlsruhe",
+        "capacity": 68,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.50€, 1 Stunde: 1.00€, 1 Tag: 7.00€, 1 Woche: 35.00€, 1 Monat Dauerparken (mind. 3 Monate): 100.00€, 1 Monat Dauerparken (fester Stellplatz): 150.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.397846,
+          48.991671
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100164",
+        "name": "Parkplatz Bahnhof Karlsruhe-Durlach",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100164",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100164/prognoses",
+        "address": "Pfinzstraße, 76228 Karlsruhe",
+        "capacity": 11,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 3.80€, 1 Woche: 19.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.463388,
+          49.002023
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100165",
+        "name": "Parkplatz Kassel Hbf Südseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100165",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100165/prognoses",
+        "address": "Franz-Ulrich-Straße, 34117 Kassel",
+        "capacity": 67,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 6.00€, 1 Woche: 30.00€, 1 Monat (am Automaten): 68.00€, 1 Monat Dauerparken (mind. 3 Monate): 68.00€, 1 Monat Dauerparken (fester Stellplatz): 100.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.488421,
+          51.317553
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100166",
+        "name": "Parkplatz Kassel Hbf Südseite hinten",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100166",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100166/prognoses",
+        "address": "Franz-Ulrich-Straße, 34117 Kassel",
+        "capacity": 81,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 4.60€, 1 Woche: 23.00€, 1 Monat (am Automaten): 53.00€, 1 Monat Dauerparken (mind. 3 Monate): 53.00€, 1 Monat Dauerparken (fester Stellplatz): 75.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.483007,
+          51.318436
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100167",
+        "name": "Parkplatz Kassel Hbf Südseite vorn",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100167",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100167/prognoses",
+        "address": "Franz-Ulrich-Straße, 34117 Kassel",
+        "capacity": 95,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 6.00€, 1 Woche: 30.00€, 1 Monat (am Automaten): 68.00€, 1 Monat Dauerparken (mind. 3 Monate): 68.00€, 1 Monat Dauerparken (fester Stellplatz): 100.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.48907,
+          51.317674
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100168",
+        "name": "Parkplatz Kassel Hbf Innenhof",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100168",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100168/prognoses",
+        "address": "Joseph-Beuys-Straße, 34117 Kassel",
+        "capacity": 11,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 68.00€, 1 Monat Dauerparken (fester Stellplatz): 100.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.488235,
+          51.319452
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100169",
         "name": "Parkplatz Bahnhof Kassel-Wilhelmshöhe",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100169",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Kassel\n34131\nBertha-von-Suttner-Straße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100169/prognoses",
+        "address": "Bertha-von-Suttner-Straße, 34131 Kassel",
         "capacity": 26,
+        "capacity_disabled": 3,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.80€, 1 Tag: 22.00€, 1 Tag rabattiert: 18.00€, 1 Monat Dauerparken (mind. 3 Monate): 165.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -506,11 +4346,22 @@
       "properties": {
         "id": "db-100170",
         "name": "Parkdeck Bahnhof Kassel-Wilhelmshöhe",
-        "type": "level",
+        "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100170",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Kassel\n34131\nBertha-von-Suttner-Straße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100170/prognoses",
+        "address": "Bertha-von-Suttner-Straße, 34131 Kassel",
         "capacity": 370,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.80€, 1 Tag: 22.00€, 1 Tag rabattiert: 18.00€, 1 Monat Dauerparken (mind. 3 Monate): 165.00€, 1 Monat Dauerparken (fester Stellplatz): 260.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -524,20 +4375,682 @@
     {
       "type": "Feature",
       "properties": {
-        "id": "db-100196",
-        "name": "Tiefgarage Magdeburg City Carré / Hbf",
+        "id": "db-100171",
+        "name": "Parkplatz Kassel-Wilhelmshöhe West",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100171",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100171/prognoses",
+        "address": "Bertha-von-Suttner-Straße, 34131 Kassel",
+        "capacity": 66,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 120.00€, 1 Monat Dauerparken (fester Stellplatz): 170.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.446001,
+          51.311637
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100172",
+        "name": "Tiefgarage Köln Hbf",
         "type": "underground",
-        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100196",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Magdeburg\n39104\nKantstraße 3\nEinfahrt: Bahnhofstraße\nAccess via Bahnhofstraße",
-        "capacity": 246,
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100172/prognoses",
+        "address": "Breslauer Platz 1/ Am alten Ufer / Kostgasse, 50668 Köln",
+        "capacity": 410,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "",
+        "operator": "Contipark Parkgaragen GmbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "20 Minuten: 0.60€, 1 Stunde: 1.80€, 1 Tag: 18.00€, 1 Tag rabattiert: 15.00€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.961059,
+          50.942634
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100173",
+        "name": "Parkplatz Köln Hbf Maximinenstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100173",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100173/prognoses",
+        "address": "Maximinenstraße, 50668 Köln",
+        "capacity": 56,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 2.50€, 1 Stunde: 5.00€, 1 Tag: 20.00€, 1 Woche: 80.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          11.628524,
-          52.129412
+          6.957985,
+          50.944694
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100174",
+        "name": "Parkplatz Köln Hbf Domplatte",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100174",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100174/prognoses",
+        "address": "Domprobst-Ketzer-Straße/An den Dominikanern, 50668 Köln",
+        "capacity": 17,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Stunde",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 3.20€, 1 Stunde: 6.40€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.957199,
+          50.942741
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100175",
+        "name": "Parkplatz Köln Hbf Trankgasse",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100175",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100175/prognoses",
+        "address": "Trankgasse, 50668 Köln",
+        "capacity": 18,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 2.50€, 1 Stunde: 5.00€, 1 Tag: 20.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.9607,
+          50.942052
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100176",
+        "name": "Parkplatz Köln Hbf Am Alten Ufer",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100176",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100176/prognoses",
+        "address": "Am Alten Ufer/Kostgasse, 50667 Köln",
+        "capacity": 95,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 2.50€, 1 Stunde: 5.00€, 1 Tag: 20.00€, 1 Woche: 80.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.961405,
+          50.942182
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100177",
+        "name": "Parkplatz Bahnhof Köln-Mülheim links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100177",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100177/prognoses",
+        "address": "Montanusstraße, 51066 Köln",
+        "capacity": 22,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 4.80€, 1 Woche: 24.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.01247,
+          50.957949
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100178",
+        "name": "Parkplatz Bahnhof Köln-Mülheim rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100178",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100178/prognoses",
+        "address": "Montanusstraße, 51065 Köln",
+        "capacity": 12,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 4.80€, 1 Woche: 24.00€, 1 Monat Dauerparken (mind. 3 Monate): 55.00€, 1 Monat Dauerparken (fester Stellplatz): 110.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.012253,
+          50.957247
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100179",
+        "name": "Parkplatz Kempten Hbf Rückseite ",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100179",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100179/prognoses",
+        "address": "Eicher Straße, 87435 Kempten im Allgäu",
+        "capacity": 120,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 3.00€, 1 Woche: 15.00€, 1 Monat (am Automaten): 33.00€, 1 Monat Dauerparken (mind. 3 Monate): 29.00€, 1 Monat Dauerparken (fester Stellplatz): 65.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.318478,
+          47.711846
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100181",
+        "name": "Parkplatz Bahnhof Kirchheim (Teck)",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100181",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100181/prognoses",
+        "address": "Schöllkopfstraße, 73230 Kirchheim unter Teck",
+        "capacity": 130,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.30€, 1 Tag: 3.20€, 1 Woche: 12.80€, 1 Monat (am Automaten): 31.00€, 1 Monat Dauerparken (mind. 3 Monate): 31.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.442324,
+          48.645001
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100182",
+        "name": "Bahnhof Kirchheim Schöllkopfstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100182",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100182/prognoses",
+        "address": "Schöllkopfstraße, 73230 Kirchheim unter Teck",
+        "capacity": 17,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Tag",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.75€, 1 Stunde: 1.50€, 1 Tag: 4.40€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.443475,
+          48.645147
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100183",
+        "name": "Bahnhof Koblenz-Ehrenbreitstein",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100183",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100183/prognoses",
+        "address": "Hofstraße, 56077 Koblenz",
+        "capacity": 60,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.20€, 1 Tag: 4.00€, 1 Woche: 20.00€, 1 Monat (am Automaten): 70.00€, 1 Monat Dauerparken (mind. 3 Monate): 65.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.610623,
+          50.361916
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100184",
+        "name": "Parkplatz Bahnhof Korntal",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100184",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100184/prognoses",
+        "address": "Ladestraße, 70825 Korntal",
+        "capacity": 19,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 2.80€, 1 Woche: 11.20€, 1 Monat (am Automaten): 25.00€, 1 Monat Dauerparken (mind. 3 Monate): 25.00€, 1 Monat Dauerparken (fester Stellplatz): 60.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.12057,
+          48.826538
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100186",
+        "name": "Parkplatz Bahnhof Kulmbach",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100186",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100186/prognoses",
+        "address": "Heinrich-von-Stephan-Straße, 95326 Kulmbach",
+        "capacity": 55,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 3.50€, 1 Woche: 17.50€, 1 Monat (am Automaten): 37.00€, 1 Monat Dauerparken (mind. 3 Monate): 37.00€, 1 Monat Dauerparken (fester Stellplatz): 75.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.453692,
+          50.109951
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100187",
+        "name": "Parkplatz Landau Hbf Maximilianstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100187",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100187/prognoses",
+        "address": "Maximilianstraße, 76829 Landau",
+        "capacity": 30,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 3.00€, 1 Woche: 15.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€, 1 Monat Dauerparken (fester Stellplatz): 65.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.125647,
+          49.199252
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100189",
+        "name": "Parkplatz Lübeck Hbf Am Güterbahnhof",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100189",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100189/prognoses",
+        "address": "Am Güterbahnhof, 23558 Lübeck",
+        "capacity": 92,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 5.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.667931,
+          53.865656
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100190",
+        "name": "Parkplatz Bahnhof Lichtenfels am Bahnhof",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100190",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100190/prognoses",
+        "address": "Bahnhofplatz/Conrad-Wagner-Straße, 96215 Lichtenfels",
+        "capacity": 10,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.50€, 1 Woche: 14.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.059114,
+          50.145509
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100191",
+        "name": "Parkplatz Bahnhof Lichtenfels am Gleis",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100191",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100191/prognoses",
+        "address": "Bgm.-Dr.-Hauptmann-Ring/Zweigstraße, 96215 Lichtenfels",
+        "capacity": 31,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.50€, 1 Woche: 14.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€, 1 Monat Dauerparken (fester Stellplatz): 70.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.060469,
+          50.146683
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100192",
+        "name": "Parkplatz Bahnhof Limburg Süd",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100192",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100192/prognoses",
+        "address": "Londoner Straße, 65552 Limburg an der Lahn",
+        "capacity": 306,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 11 Tage oder 4-Wochen-Parkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Parkscheine und Dauerparkkarten nur auf dem Parkplatz gültig. Parkkarten für das Parkhaus der Kreisstadt Limburg an der Lahn haben auf dieser Fläche keine Gültigkeit.",
+        "has_fee": true,
+        "fee_description": "1 Tag: 2.70€, 1 Woche: 18.90€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€, 1 Monat Dauerparken (fester Stellplatz): 70.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.093938,
+          50.383503
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100193",
+        "name": "Parkplatz Bahnhof Lindau-Insel",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100193",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100193/prognoses",
+        "address": "Bahnhof 1e, 88131 Lindau",
+        "capacity": 32,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.50€, 1 Tag: 13.00€, 1 Woche: 65.00€, 1 Monat Dauerparken (mind. 3 Monate): 110.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.68095,
+          47.543496
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100195",
+        "name": "Parkplatz Ludwigshafen (Rhein) Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100195",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100195/prognoses",
+        "address": "Richard-Dehmel-Straße, 67061 Ludwigshafen",
+        "capacity": 90,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.50€, 1 Stunde: 1.00€, 1 Tag: 2.40€, 1 Woche: 12.00€, 1 Monat (am Automaten): 29.00€, 1 Monat Dauerparken (mind. 3 Monate): 29.00€, 1 Monat Dauerparken (fester Stellplatz): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.433783,
+          49.475042
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100196",
+        "name": "Tiefgarage Magdeburg City Carré / Hbf",
+        "type": "underground",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100196",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100196/prognoses",
+        "address": "Kantstraße 3, 39104 Magdeburg",
+        "capacity": 431,
+        "capacity_disabled": 16,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Komfortparken auf den Ebenen Süd -1 und -2",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.30€, 1 Tag: 14.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.629296,
+          52.131125
         ]
       }
     },
@@ -548,16 +5061,58 @@
         "name": "Tiefgarage Magdeburg City Carré / Hbf - Tiefpreisparken",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100197",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Magdeburg\n39104\nKantstraße 3\nEinfahrt: Bahnhofstraße\nAccess via Bahnhofstraße",
-        "capacity": 904,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100197/prognoses",
+        "address": "Kantstraße 3, 39104 Magdeburg",
+        "capacity": 719,
+        "capacity_disabled": 16,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Tiefpreisparken Ebenen Süd -3, Nord -1, -2, -3",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.30€, 1 Tag: 5.50€, 1 Monat Dauerparken (mind. 3 Monate): 95.00€, 1 Monat Dauerparken (fester Stellplatz): 140.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
         "type": "Point",
         "coordinates": [
-          11.628676,
-          52.129485
+          11.629129,
+          52.131034
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100198",
+        "name": "Parkplatz Magdeburg Hbf Maybachstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100198",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100198/prognoses",
+        "address": "Maybachstraße, 39104 Magdeburg",
+        "capacity": 152,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 7.50€, 1 Woche: 30.00€, 1 Monat (am Automaten): 80.00€, 1 Monat Dauerparken (mind. 3 Monate): 80.00€, 1 Monat Dauerparken (fester Stellplatz): 140.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.624166,
+          52.130202
         ]
       }
     },
@@ -565,12 +5120,23 @@
       "type": "Feature",
       "properties": {
         "id": "db-100201",
-        "name": "Tiefgarage Bonifazius-Türme UG -1",
+        "name": "Mainz Hbf Tiefgarage Bonifazius-Türme UG -1",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100201",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Mainz\n55118\nBonifaziusstraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100201/prognoses",
+        "address": "Bonifaziusstraße, 55118 Mainz",
         "capacity": 200,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.20€, 1 Tag: 12.00€, 1 Monat Dauerparken (mind. 3 Monate): 135.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -585,12 +5151,23 @@
       "type": "Feature",
       "properties": {
         "id": "db-100202",
-        "name": "Tiefgarage Bonifazius-Türme UG -2",
+        "name": "Mainz Hbf Tiefgarage Bonifazius-Türme UG -2",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100202",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Mainz\n55118\nBonifaziusstraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100202/prognoses",
+        "address": "Bonifaziusstraße, 55118 Mainz",
         "capacity": 219,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.20€, 1 Tag: 6.00€, 1 Monat Dauerparken (mind. 3 Monate): 135.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -604,13 +5181,241 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100203",
+        "name": "Mainz Hbf Parkhaus CityPort",
+        "type": "garage",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100203/prognoses",
+        "address": "Binger Straße 19 / Am Linsenberg, 55131 Mainz",
+        "capacity": 1100,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "",
+        "operator": "PMG Parken in Mainz GmbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.80€, 1 Tag: 15.00€, 1 Tag rabattiert: 10.50€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.257973,
+          49.998685
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100204",
+        "name": "Vorfahrt Bahnhof Mainz-Kastel",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100204",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100204/prognoses",
+        "address": "Eisenbahnstraße, 55252 Wiesbaden",
+        "capacity": 26,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 9 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 5.00€, 1 Woche: 20.00€, 1 Monat (am Automaten): 33.00€, 1 Monat Dauerparken (mind. 3 Monate): 33.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.282937,
+          50.007078
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100205",
+        "name": "Bahnhof Mainz-Kastel Rückseite am Gleis",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100205",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100205/prognoses",
+        "address": "Rheinufer 6, 55252 Wiesbaden",
+        "capacity": 60,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 6.00€, 1 Woche: 24.00€, 1 Monat (am Automaten): 27.00€, 1 Monat Dauerparken (mind. 3 Monate): 27.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.283953,
+          50.005802
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100206",
+        "name": "Bahnhof Mainz-Kastel Rückseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100206",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100206/prognoses",
+        "address": "Rheinufer 4-6, 55252 Wiesbaden",
+        "capacity": 60,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 6.00€, 1 Woche: 24.00€, 1 Monat (am Automaten): 27.00€, 1 Monat Dauerparken (mind. 3 Monate): 27.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.282604,
+          50.006352
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100207",
+        "name": "Vorfahrt Bahnhof Marktredwitz",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100207",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100207/prognoses",
+        "address": "Bahnhofsplatz, 95615 Marktredwitz",
+        "capacity": 15,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 5.00€, 1 Woche: 20.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.082974,
+          50.004175
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100208",
+        "name": "Parkplatz Bahnhof Marktredwitz links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100208",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100208/prognoses",
+        "address": "Bahnhofsplatz 7, 95615 Marktredwitz",
+        "capacity": 25,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 5.00€, 1 Woche: 20.00€, 1 Monat (am Automaten): 43.00€, 1 Monat Dauerparken (mind. 3 Monate): 43.00€, 1 Monat Dauerparken (fester Stellplatz): 60.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.082342,
+          50.003998
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100209",
+        "name": "Parkplatz Bahnhof Marktredwitz rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100209",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100209/prognoses",
+        "address": "Kraußoldstraße, 95615 Marktredwitz",
+        "capacity": 40,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.50€, 1 Stunde: 1.00€, 1 Tag: 3.00€, 1 Woche: 12.00€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€, 1 Monat Dauerparken (fester Stellplatz): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.084939,
+          50.005032
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100213",
         "name": "Tiefgarage München Hauptbahnhof Süd",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100213",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "München\n80336\nSenefelderstraße/Goethestraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100213/prognoses",
+        "address": "Senefelderstraße 6 / Goethestraße, 80336 München",
         "capacity": 242,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 3.00€, 1 Tag: 29.00€, 1 Tag rabattiert: 24.00€, 1 Monat Dauerparken (mind. 3 Monate): 190.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -624,13 +5429,613 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100214",
+        "name": "Tiefgarage Pasinger Hofgärten",
+        "type": "underground",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100214/prognoses",
+        "address": "Kaflerstraße, 81241 München Pasing",
+        "capacity": 350,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "",
+        "operator": "Bayerisches Rotes Kreuz",
+        "description": "Langzeitparker bitte UG 2 benutzen.",
+        "has_fee": true,
+        "fee_description": "1 Tag: 12.00€, 1 Tag rabattiert: 9.00€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.46019,
+          48.14903
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100217",
+        "name": "Parkplatz Bahnhof Memmingen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100217",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100217/prognoses",
+        "address": "Bahnhofstraße, 87700 Memmingen",
+        "capacity": 16,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 10.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.186595,
+          47.98628
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100218",
+        "name": "Vorfahrt Bahnhof Minden",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100218",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100218/prognoses",
+        "address": "Viktoriastraße, 32423 Minden",
+        "capacity": 20,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 8.00€, 1 Woche: 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.933625,
+          52.288981
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100219",
+        "name": "Parkplatz Bahnhof Minden Schwarzer Weg ",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100219",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100219/prognoses",
+        "address": "Kaiserstraße/Schwarzer Weg, 32423 Minden",
+        "capacity": 80,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 4.30€, 1 Woche: 21.50€, 1 Monat (am Automaten): 36.00€, 1 Monat Dauerparken (mind. 3 Monate): 36.00€, 1 Monat Dauerparken (fester Stellplatz): 70.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.932415,
+          52.289133
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100220",
+        "name": "Parkplatz Bahnhof Minden am Gleis",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100220",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100220/prognoses",
+        "address": "Bahnstraße, 32423 Minden",
+        "capacity": 124,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 8 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 6.00€, 1 Woche: 24.00€, 1 Monat (am Automaten): 36.00€, 1 Monat Dauerparken (mind. 3 Monate): 36.00€, 1 Monat Dauerparken (fester Stellplatz): 70.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.936169,
+          52.290723
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100221",
+        "name": "Bahnhof Minden Schwarzer Weg Süd",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100221",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100221/prognoses",
+        "address": "Schwarzer Weg, 32423 Minden",
+        "capacity": 15,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 22.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.932712,
+          52.288661
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100222",
+        "name": "Parkhaus am Hauptbahnhof Nürnberg",
+        "type": "garage",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100222/prognoses",
+        "address": "Bahnhofsplatz 5, 90443 Nürnberg",
+        "capacity": 486,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "",
+        "operator": "Cologne Parkhaus Service GmbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.50€, 1 Stunde: 3.00€, 1 Tag: 22.00€, 1 Tag rabattiert: 15.00€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.08144,
+          49.44629
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100223",
+        "name": "Vorplatz Neunkirchen Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100223",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100223/prognoses",
+        "address": "Am Bahnhof, 66538 Neunkirchen an der Saar",
+        "capacity": 42,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 2.40€, 1 Woche: 12.00€, 1 Monat (am Automaten): 29.00€, 1 Monat Dauerparken (mind. 3 Monate): 29.00€, 1 Monat Dauerparken (fester Stellplatz): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.177799,
+          49.353431
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100224",
+        "name": "Parkplatz Neunkirchen Hbf an den Gleisen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100224",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100224/prognoses",
+        "address": "Am Bahnhof, 66538 Neunkirchen an der Saar",
+        "capacity": 28,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 2.40€, 1 Woche: 12.00€, 1 Monat (am Automaten): 29.00€, 1 Monat Dauerparken (mind. 3 Monate): 29.00€, 1 Monat Dauerparken (fester Stellplatz): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.177385,
+          49.353667
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100225",
+        "name": "Vorplatz Neuss Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100225",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100225/prognoses",
+        "address": "Zufuhrstraße/Further Straße 1, 41460 Neuss",
+        "capacity": 20,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 6.00€, 1 Woche: 30.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.683308,
+          51.203641
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100228",
+        "name": "Parkplatz Neustadt Hbf links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100228",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100228/prognoses",
+        "address": "Bahnhofsplatz, 67434 Neustadt an der Weinstraße",
+        "capacity": 84,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Sondertarif zum Weinlesefest vom 22.09. bis 09.10.2023 von 14:00 Uhr bis 03:00 Uhr: je Stunde 2,00 €, pro Tag 10,00 €. ",
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.75€, 1 Stunde: 1.50€, 1 Tag: 4.50€, 1 Woche: 18.00€, 1 Monat Dauerparken (mind. 3 Monate): 52.00€, 1 Monat Dauerparken (fester Stellplatz): 100.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.141814,
+          49.349919
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100229",
+        "name": "Parkplatz Neustadt Hbf Landauer Straße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100229",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100229/prognoses",
+        "address": "Landauer Straße 43, 67433 Neustadt an der Weinstraße",
+        "capacity": 67,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Sondertarif zum Weinlesefest vom 22.09. bis 09.10.2023 von 14:00 Uhr bis 03:00 Uhr: je Stunde 2,00 €, pro Tag 10,00 €. ",
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.75€, 1 Stunde: 1.50€, 1 Tag: 4.50€, 1 Woche: 18.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.143048,
+          49.350209
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100231",
+        "name": "Parkplatz Bahnhof Nordhausen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100231",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100231/prognoses",
+        "address": "Lange Straße, 99734 Nordhausen",
+        "capacity": 31,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 4.50€, 1 Woche: 18.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€, 1 Monat Dauerparken (fester Stellplatz): 85.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.790216,
+          51.492974
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100232",
+        "name": "Parkplatz Bahnhof Offenburg Rheinstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100232",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100232/prognoses",
+        "address": "Hauptstraße / Rheinstraße, 77652 Offenburg",
+        "capacity": 71,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 5.00€, 1 Woche: 20.00€, 1 Monat (am Automaten): 60.00€, 1 Monat Dauerparken (mind. 3 Monate): 60.00€, 1 Monat Dauerparken (fester Stellplatz): 115.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.946301,
+          48.478493
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100233",
+        "name": "Parkplatz Offenburg Rammersweierstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100233",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100233/prognoses",
+        "address": "Rammersweierstraße, 77652 Offenburg",
+        "capacity": 56,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 2.50€, 1 Woche: 17.50€, 1 Monat (am Automaten): 60.00€, 1 Monat Dauerparken (mind. 3 Monate): 60.00€, 1 Monat Dauerparken (fester Stellplatz): 115.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.949068,
+          48.478112
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100234",
+        "name": "Parkplatz Osnabrück Hbf Humboldtbrücke",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100234",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100234/prognoses",
+        "address": "An der Humboldtbrücke 8, 49074 Osnabrück",
+        "capacity": 70,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 9 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 7.00€, 1 Woche: 35.00€, 1 Monat (am Automaten): 55.00€, 1 Monat Dauerparken (mind. 3 Monate): 52.00€, 1 Monat Dauerparken (fester Stellplatz): 110.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.059765,
+          52.274256
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100235",
+        "name": "Parkplatz Osnabrück Hbf Eisenbahnstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100235",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100235/prognoses",
+        "address": "Eisenbahnstraße, 49074 Osnabrück",
+        "capacity": 36,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.60€, 1 Tag: 9.00€, 1 Woche: 45.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.057658,
+          52.274056
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100237",
+        "name": "Vorfahrt Passau Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100237",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100237/prognoses",
+        "address": "Bahnhofstraße, 94032 Passau",
+        "capacity": 7,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Tag",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 8.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.451078,
+          48.57418
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100238",
+        "name": "Parkplatz Passau Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100238",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100238/prognoses",
+        "address": "Bahnhofstraße 29, 94032 Passau",
+        "capacity": 52,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.70€, 1 Tag: 5.50€, 1 Woche: 27.50€, 1 Monat (am Automaten): 70.00€, 1 Monat Dauerparken (mind. 3 Monate): 70.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.447566,
+          48.574245
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100240",
-        "name": "Parkhaus Donaupassage",
+        "name": "Passau Hbf Parkhaus Donaupassage",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100240",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Passau\n94032\nObere Donaulände",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100240/prognoses",
+        "address": "Obere Donaulände, 94032 Passau",
         "capacity": 559,
+        "capacity_disabled": 4,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 5.00€, 1 Monat Dauerparken (mind. 3 Monate): 75.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -644,13 +6049,55 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100241",
+        "name": "Parkplatz Bahnhof Plattling Lagerhausstr",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100241",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100241/prognoses",
+        "address": "Lagerhausstraße, 94447 Plattling",
+        "capacity": 120,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.50€, 1 Stunde: 1.00€, 1 Tag: 3.50€, 1 Woche: 12.00€, 1 Monat (am Automaten): 35.00€, 1 Monat Dauerparken (mind. 3 Monate): 35.00€, 1 Monat Dauerparken (fester Stellplatz): 55.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.862637,
+          48.778701
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100242",
         "name": "Parkhaus Bahnhof Plochingen",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100242",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Plochingen\n73207\nEisenbahnstraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100242/prognoses",
+        "address": "Eisenbahnstraße, 73207 Plochingen",
         "capacity": 268,
+        "capacity_disabled": 3,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 4.70€, 1 Woche: 18.80€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -664,13 +6111,179 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100243",
+        "name": "Parkplatz Bahnhof Prien links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100243",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100243/prognoses",
+        "address": "Bahnhofstraße, 83209 Prien am Chiemsee",
+        "capacity": 33,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 4.80€, 1 Woche: 19.20€, 1 Monat (am Automaten): 60.00€, 1 Monat Dauerparken (mind. 3 Monate): 60.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.34638,
+          47.855681
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100246",
+        "name": "Parkplatz Bahnhof Rastatt rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100246",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100246/prognoses",
+        "address": "Steinmetzstraße, 76437 Rastatt",
+        "capacity": 16,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.20€, 1 Tag: 4.00€, 1 Woche: 16.00€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.214545,
+          48.859677
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100247",
+        "name": "Vorplatz Recklinghausen Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100247",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100247/prognoses",
+        "address": "Große-Perdekamp-Straße 21, 45657 Recklinghausen",
+        "capacity": 15,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 10.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.20332,
+          51.616723
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100248",
+        "name": "Vorfahrt Regensburg Hbf rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100248",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100248/prognoses",
+        "address": "Bahnhofstraße, 93047 Regensburg",
+        "capacity": 7,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 4 Stunden",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.50€, 1 Stunde: 3.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.098552,
+          49.012361
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100249",
+        "name": "Vorfahrt Regensburg Hbf links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100249",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100249/prognoses",
+        "address": "Bahnhofstraße, 93047 Regensburg",
+        "capacity": 58,
+        "capacity_disabled": 0,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.30€, 1 Stunde: 2.60€, 1 Tag: 11.00€, 1 Woche: 55.00€, 1 Monat Dauerparken (mind. 3 Monate): 145.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.100109,
+          49.012395
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100252",
         "name": "Tiefgarage Hauptbahnhof / Castra Regina Center",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100252",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Regensburg\n93047\nBahnhofstraße 24",
-        "capacity": 409,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100252/prognoses",
+        "address": "Bahnhofstraße 24, 93047 Regensburg",
+        "capacity": 391,
+        "capacity_disabled": 4,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.20€, 1 Stunde: 2.40€, 1 Tag: 14.00€, 1 Tag rabattiert: 12.00€, 1 Monat (am Automaten): 110.00€, 1 Monat Dauerparken (mind. 3 Monate): 100.00€, 1 Monat Dauerparken (fester Stellplatz): 160.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -684,13 +6297,644 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100253",
+        "name": "Parkplatz Regensburg Hbf Sternbergstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100253",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100253/prognoses",
+        "address": "Sternbergstraße, 93047 Regensburg",
+        "capacity": 101,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Tag: 4.30€, 1 Woche: 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 75.00€, 1 Monat Dauerparken (fester Stellplatz): 120.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.103526,
+          49.011477
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100254",
+        "name": "Vorplatz Bahnhof Rheine",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100254",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100254/prognoses",
+        "address": "Kardinal-Galen-Ring, 48431 Rheine",
+        "capacity": 30,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 10.00€, 1 Woche: 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.435473,
+          52.276321
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100255",
+        "name": "Parkplatz Bahnhof Riesa",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100255",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100255/prognoses",
+        "address": "Bahnhofstraße, 01587 Riesa",
+        "capacity": 35,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 9 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 3.00€, 1 Woche: 12.00€, 1 Monat (am Automaten): 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€, 1 Monat Dauerparken (fester Stellplatz): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.286473,
+          51.309029
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100256",
+        "name": "Vorfahrt Saarbrücken Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100256",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100256/prognoses",
+        "address": "Am Hauptbahnhof 4, 66111 Saarbrücken",
+        "capacity": 53,
+        "capacity_disabled": 3,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.30€, 1 Stunde: 2.60€, 1 Tag: 20.00€, 1 Woche: 80.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.990164,
+          49.240564
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100257",
+        "name": "Parkplatz Saarbrücken Hbf Viktoriastraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100257",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100257/prognoses",
+        "address": "Viktoriastraße, 66111 Saarbrücken",
+        "capacity": 44,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.50€, 1 Tag: 12.00€, 1 Woche: 49.50€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.992471,
+          49.239765
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100259",
+        "name": "Parkplatz Saarbrücken Hbf am Gleis",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100259",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100259/prognoses",
+        "address": "Viktoriastraße, 66111 Saarbrücken",
+        "capacity": 78,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.20€, 1 Stunde: 2.40€, 1 Tag: 6.00€, 1 Woche: 36.00€, 1 Monat (am Automaten): 105.00€, 1 Monat Dauerparken (mind. 3 Monate): 105.00€, 1 Monat Dauerparken (fester Stellplatz): 190.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.993225,
+          49.24073
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100260",
+        "name": "Saarbrücken Hbf Viktoriastraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100260",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100260/prognoses",
+        "address": "Viktoriastraße, 66111 Saarbrücken",
+        "capacity": 6,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.50€, 1 Tag: 12.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.993238,
+          49.240129
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100261",
+        "name": "Parkplatz Bahnhof Schlüchtern links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100261",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100261/prognoses",
+        "address": "Am Bahnhof, 36381 Schlüchtern",
+        "capacity": 200,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 3.30€, 1 Woche: 13.20€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€, 1 Monat Dauerparken (fester Stellplatz): 45.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.509042,
+          50.340624
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100262",
+        "name": "Parkplatz Bahnhof Schlüchtern",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100262",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100262/prognoses",
+        "address": "Am Bahnhof, 36381 Schlüchtern",
+        "capacity": 235,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 3.30€, 1 Woche: 13.20€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€, 1 Monat Dauerparken (fester Stellplatz): 45.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.510537,
+          50.340972
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100263",
+        "name": "Parkplatz Bahnhof Schwandorf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100263",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100263/prognoses",
+        "address": "Bahnhofplatz, 92421 Schwandorf",
+        "capacity": 20,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.20€, 1 Tag: 4.50€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.103842,
+          49.327116
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100264",
+        "name": "Parkplatz Schweinfurt Hbf links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100264",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100264/prognoses",
+        "address": "Hauptbahnhofstraße, 97424 Schweinfurt",
+        "capacity": 10,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 5.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.213094,
+          50.035711
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100265",
+        "name": "Parkplatz Schweinfurt Hbf rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100265",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100265/prognoses",
+        "address": "Gustav-Heusinger-Straße, 97424 Schweinfurt",
+        "capacity": 135,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 5.00€, 1 Woche: 20.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€, 1 Monat Dauerparken (fester Stellplatz): 60.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          10.210229,
+          50.035242
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100267",
+        "name": "Parkplatz Siegen Hbf Morleystraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100267",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100267/prognoses",
+        "address": "Morleystraße, 57072 Siegen",
+        "capacity": 84,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.80€, 1 Tag: 12.00€, 1 Woche: 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.014856,
+          50.873405
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100268",
+        "name": "Parkplatz Bahnhof Singen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100268",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100268/prognoses",
+        "address": "Bahnhofstraße, 78224 Singen (Hohentwiel)",
+        "capacity": 69,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Parkscheine der Stadt haben auf dieser Fläche keine Gültigkeit.",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.70€, 1 Tag: 7.20€, 1 Woche: 36.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.84241,
+          47.759793
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100269",
+        "name": "Parkplatz Bahnhof Steinau",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100269",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100269/prognoses",
+        "address": "Bahnhofstraße, 36396 Steinau an der Straße",
+        "capacity": 65,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 3.30€, 1 Woche: 13.20€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€, 1 Monat Dauerparken (fester Stellplatz): 45.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.444647,
+          50.314117
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100270",
+        "name": "Parkplatz Bahnhof Steinau Rückseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100270",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100270/prognoses",
+        "address": "Marborner Straße, 36396 Steinau an der Straße",
+        "capacity": 75,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 3.30€, 1 Woche: 13.20€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€, 1 Monat Dauerparken (fester Stellplatz): 45.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.442472,
+          50.314554
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100271",
+        "name": "Parkplatz Stendal Hauptbahnhof rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100271",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100271/prognoses",
+        "address": "Bahnhofstraße, 39576 Stendal",
+        "capacity": 74,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.00€, 1 Woche: 10.00€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€, 1 Monat Dauerparken (fester Stellplatz): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.853261,
+          52.594989
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100272",
+        "name": "Vorfahrt Stralsund Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100272",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100272/prognoses",
+        "address": "Tribseer Damm, 18437 Stralsund",
+        "capacity": 11,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 17.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.077329,
+          54.309057
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100273",
+        "name": "Vorfahrt Bahnhof Straubing",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100273",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100273/prognoses",
+        "address": "Bahnhofplatz, 94315 Straubing",
+        "capacity": 8,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 7.00€, 1 Woche: 28.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.574244,
+          48.877317
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100274",
+        "name": "Parkplatz Bahnhof Straubing links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100274",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100274/prognoses",
+        "address": "Bahnhofplatz, 94315 Straubing",
+        "capacity": 18,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 7.00€, 1 Woche: 28.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.57473,
+          48.877124
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100275",
         "name": "Stuttgart Hbf Tiefgarage LBBW",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100275",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Stuttgart\n70173\nAm Hauptbahnhof 2",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100275/prognoses",
+        "address": "Am Hauptbahnhof 2, 70173 Stuttgart",
         "capacity": 1287,
+        "capacity_disabled": 41,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 2.00€, 1 Stunde: 3.00€, 1 Tag: 23.00€, 1 Tag rabattiert: 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 160.00€, 1 Monat Dauerparken (fester Stellplatz): 210.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -705,12 +6949,23 @@
       "type": "Feature",
       "properties": {
         "id": "db-100278",
-        "name": "Parkhaus Wilhelmsplatz Ebenen 7 bis 12",
+        "name": "Stuttgart-Bad Cannstatt Parkhaus Wilhelmsplatz Ebenen 7 bis 12",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100278",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Stuttgart\n70372\nEisenbahnstraße 12",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100278/prognoses",
+        "address": "Eisenbahnstraße 12, 70372 Stuttgart",
         "capacity": 157,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "05:00-24:00",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 3.00€, 1 Monat Dauerparken (mind. 3 Monate): 95.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -725,12 +6980,23 @@
       "type": "Feature",
       "properties": {
         "id": "db-100279",
-        "name": "Parkhaus Wilhelmsplatz Ebenen -1 bis 6",
+        "name": "Stuttgart-Bad Cannstatt Parkhaus Wilhelmsplatz Ebenen -1 bis 6",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100279",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Stuttgart\n70372\nEisenbahnstraße 12",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100279/prognoses",
+        "address": "Eisenbahnstraße 12, 70372 Stuttgart",
         "capacity": 161,
+        "capacity_disabled": 3,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "05:00-24:00",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 10.00€, 1 Monat Dauerparken (mind. 3 Monate): 95.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -745,12 +7011,23 @@
       "type": "Feature",
       "properties": {
         "id": "db-100280",
-        "name": "Parkhaus Wilhelmsplatz Ebenen -3 und -2",
+        "name": "Stuttgart-Bad Cannstatt Parkhaus Wilhelmsplatz Ebenen -3 und -2",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100280",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Stuttgart\n70372\nEisenbahnstraße 12",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100280/prognoses",
+        "address": "Eisenbahnstraße 12, 70372 Stuttgart",
         "capacity": 43,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "05:00-24:00",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 3.00€, 1 Monat Dauerparken (mind. 3 Monate): 95.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -768,9 +7045,20 @@
         "name": "Parkplatz Bahnhof Stuttgart-Vaihingen",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100281",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Stuttgart\n70563\nBahnhof (Vaihingen) 1",
-        "capacity": 74,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100281/prognoses",
+        "address": "Bahnhof (Vaihingen) 1, 70563 Stuttgart",
+        "capacity": 69,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 3.00€, 1 Woche: 15.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -784,14 +7072,242 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100282",
+        "name": "Parkplatz Bahnhof Stuttgart-Zuffenhausen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100282",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100282/prognoses",
+        "address": "Am Bahnhof, 70435 Stuttgart",
+        "capacity": 173,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.30€, 1 Woche: 16.50€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 45.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.165506,
+          48.830276
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100284",
+        "name": "Bahnhof Zuffenhausen Straßenparkplatz",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100284",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100284/prognoses",
+        "address": "Am Bahnhof, 70435 Stuttgart",
+        "capacity": 35,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.30€, 1 Woche: 16.50€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.165245,
+          48.831285
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100285",
+        "name": "Parkplatz Tübingen Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100285",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100285/prognoses",
+        "address": "Hegelstraße, 72072 Tübingen",
+        "capacity": 56,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 10.00€, 1 Woche: 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.056824,
+          48.515235
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100286",
+        "name": "Parkpkatz Bahnhof Treysa",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100286",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100286/prognoses",
+        "address": "Bahnhofstraße, 34613 Schwalmstadt-Treysa",
+        "capacity": 35,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 4.00€, 1 Woche: 16.00€, 1 Monat (am Automaten): 35.00€, 1 Monat Dauerparken (mind. 3 Monate): 35.00€, 1 Monat Dauerparken (fester Stellplatz): 50.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.186498,
+          50.910952
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100287",
+        "name": "Vorfahrt Trier Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100287",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100287/prognoses",
+        "address": "Bahnhofsplatz, 54292 Trier",
+        "capacity": 9,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.20€, 1 Stunde: 2.40€, 1 Tag: 17.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.651553,
+          49.756924
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100289",
+        "name": "Parkplatz Bahnhof Troisdorf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100289",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100289/prognoses",
+        "address": "Bahnstraße/Sieglarer Straße, 53842 Troisdorf",
+        "capacity": 170,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 3.20€, 1 Woche: 16.00€, 1 Monat (am Automaten): 34.00€, 1 Monat Dauerparken (mind. 3 Monate): 34.00€, 1 Monat Dauerparken (fester Stellplatz): 55.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.148731,
+          50.813557
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100290",
+        "name": "Kurzzeitparkplatz Ulm Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100290",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100290/prognoses",
+        "address": "Friedrich-Ebert-Straße, 89073 Ulm",
+        "capacity": 29,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Tag",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.20€, 1 Stunde: 2.40€, 1 Tag: 25.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.98338,
+          48.40016
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100291",
         "name": "Parkplatz Ulm Hauptbahnhof",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100291",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Ulm\n89073\nFriedrich-Ebert-Straße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100291/prognoses",
+        "address": "Friedrich-Ebert-Straße, 89073 Ulm",
         "capacity": 177,
-        "has_live_capacity": true
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Einfach parken! (Kurzanleitung als PDF)",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.50€, 1 Tag: 10.00€, 1 Tag rabattiert: 9.00€, 1 Monat Dauerparken (mind. 3 Monate): 170.00€, 1 Monat Dauerparken (fester Stellplatz): 290.00€",
+        "park_ride": true,
+        "has_live_capacity": false
       },
       "geometry": {
         "type": "Point",
@@ -804,13 +7320,489 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100292",
+        "name": "Parkplatz Bahnhof Völklingen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100292",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100292/prognoses",
+        "address": "Rathausstraße, 66333 Völklingen",
+        "capacity": 26,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Stellplätze sind überdacht.",
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.65€, 1 Stunde: 1.30€, 1 Tag: 6.00€, 1 Woche: 24.00€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 45.00€, 1 Monat Dauerparken (fester Stellplatz): 95.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.849948,
+          49.248528
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100293",
+        "name": "Vorplatz Bahnhof Warnemünde",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100293",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100293/prognoses",
+        "address": "Am Bahnhof, 18119 Warnemünde",
+        "capacity": 11,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Tag",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 2.00€, 1 Stunde: 2.50€, 1 Tag: 15.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.090144,
+          54.17734
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100294",
+        "name": "Parkplatz Bahnhof Wächtersbach links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100294",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100294/prognoses",
+        "address": "Am Bahnhof, 63607 Wächtersbach",
+        "capacity": 46,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 11 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.50€, 1 Woche: 17.50€, 1 Monat (am Automaten): 34.00€, 1 Monat Dauerparken (mind. 3 Monate): 34.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.295895,
+          50.254544
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100295",
+        "name": "Parkplatz Bahnhof Wächtersbach rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100295",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100295/prognoses",
+        "address": "Main-Kinzig-Straße/Bahnhofstraße, 63607 Wächtersbach",
+        "capacity": 280,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 11 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.50€, 1 Woche: 17.50€, 1 Monat (am Automaten): 34.00€, 1 Monat Dauerparken (mind. 3 Monate): 34.00€, 1 Monat Dauerparken (fester Stellplatz): 55.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.294769,
+          50.253615
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100296",
+        "name": "Parkplatz Bahnhof Wächtersbach gegenüber",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100296",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100296/prognoses",
+        "address": "Bahnhofstraße, 63607 Wächtersbach",
+        "capacity": 45,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 11 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.50€, 1 Woche: 17.50€, 1 Monat (am Automaten): 34.00€, 1 Monat Dauerparken (mind. 3 Monate): 34.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.296179,
+          50.255227
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100297",
+        "name": "Vorplatz Würzburg Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100297",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100297/prognoses",
+        "address": "Bahnhofplatz, 97070 Würzburg",
+        "capacity": 79,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.30€, 1 Stunde: 2.60€, 1 Tag: 18.00€, 1 Woche: 126.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.936565,
+          49.801156
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100298",
+        "name": "Parkplatz Bahnhof Weiden",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100298",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100298/prognoses",
+        "address": "Bahnhofstraße, 92637 Weiden in der Oberpfalz",
+        "capacity": 18,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.75€, 1 Stunde: 1.50€, 1 Tag: 4.80€, 1 Woche: 19.20€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.154545,
+          49.67054
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100299",
+        "name": "Parkplatz Bahnhof Weiden rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100299",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100299/prognoses",
+        "address": "Bahnhofstraße, 92637 Weiden in der Oberpfalz",
+        "capacity": 39,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.75€, 1 Stunde: 1.50€, 1 Tag: 4.20€, 1 Woche: 16.80€, 1 Monat (am Automaten): 45.00€, 1 Monat Dauerparken (mind. 3 Monate): 45.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.154471,
+          49.671179
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100300",
+        "name": "Parkplatz Bahnhof Weilheim links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100300",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100300/prognoses",
+        "address": "Bahnhofstraße, 82362 Weilheim in Oberbayern",
+        "capacity": 22,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 3.10€, 1 Woche: 12.40€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.142709,
+          47.844385
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100301",
+        "name": "Parkplatz Bahnhof Weilheim Bahnhofsallee",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100301",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100301/prognoses",
+        "address": "Bahnhofsallee 2c, 82362 Weilheim in Oberbayern",
+        "capacity": 55,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 3.10€, 1 Woche: 12.40€, 1 Monat (am Automaten): 39.00€, 1 Monat Dauerparken (mind. 3 Monate): 39.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.144531,
+          47.844839
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100302",
+        "name": "Parkplatz Bahnhof Weimar rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100302",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100302/prognoses",
+        "address": "Schopenhauerstraße, 99423 Weimar",
+        "capacity": 18,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 6.00€, 1 Woche: 24.00€, 1 Monat Dauerparken (mind. 3 Monate): 70.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.327295,
+          50.991133
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100303",
+        "name": "Parkplatz Bahnhof Weimar links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100303",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100303/prognoses",
+        "address": "Schopenhauerstraße, 99423 Weimar",
+        "capacity": 39,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.90€, 1 Stunde: 1.80€, 1 Tag: 6.00€, 1 Woche: 24.00€, 1 Monat (am Automaten): 60.00€, 1 Monat Dauerparken (mind. 3 Monate): 60.00€, 1 Monat Dauerparken (fester Stellplatz): 90.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.324952,
+          50.991266
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100304",
+        "name": "Vorplatz Wiesbaden Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100304",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100304/prognoses",
+        "address": "Salzbachstraße, 65189 Wiesbaden",
+        "capacity": 53,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.30€, 1 Stunde: 2.60€, 1 Tag: 5.00€, 1 Woche: 25.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.245044,
+          50.070549
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100306",
+        "name": "Parkplatz Wiesbaden Hbf Ostseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100306",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100306/prognoses",
+        "address": "Salzbachstraße, 65189 Wiesbaden",
+        "capacity": 104,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 4.50€, 1 Woche: 22.50€, 1 Monat (am Automaten): 75.00€, 1 Monat Dauerparken (mind. 3 Monate): 75.00€, 1 Monat Dauerparken (fester Stellplatz): 130.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.245424,
+          50.069028
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100307",
+        "name": "Parkplatz Wittlich Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100307",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100307/prognoses",
+        "address": "Bahnhofstraße, 54516 Wittlich",
+        "capacity": 105,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 10 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 1.50€, 1 Woche: 6.00€, 1 Monat (am Automaten): 12.00€, 1 Monat Dauerparken (mind. 3 Monate): 12.00€, 1 Monat Dauerparken (fester Stellplatz): 18.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.943295,
+          49.973341
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-100308",
         "name": "Parkdeck Wolfsburg Hauptbahnhof",
-        "type": "level",
+        "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100308",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Wolfsburg\n38440\nWilly-Brandt-Platz",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100308/prognoses",
+        "address": "Willy-Brandt-Platz, 38440 Wolfsburg",
         "capacity": 190,
+        "capacity_disabled": 4,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 7.00€, 1 Tag rabattiert: 5.00€, 1 Monat Dauerparken (mind. 3 Monate): 90.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -828,9 +7820,20 @@
         "name": "Tiefgarage Wolfsburg Hauptbahnhof / Kino",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100309",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Wolfsburg\n38440\nWilly-Brandt-Platz",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100309/prognoses",
+        "address": "Willy-Brandt-Platz, 38440 Wolfsburg",
         "capacity": 113,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.60€, 1 Tag: 10.00€, 1 Monat Dauerparken (mind. 3 Monate): 125.00€, 1 Monat Dauerparken (fester Stellplatz): 190.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -844,13 +7847,396 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-100311",
+        "name": "Parkplatz Bahnhof Oberbarmen links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100311",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100311/prognoses",
+        "address": "Rosenau 10, 42277 Wuppertal",
+        "capacity": 8,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "PRBL - Parkraumbewirtschaftung Linne",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.220713,
+          51.274357
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100312",
+        "name": "Parkplatz Bahnhof Oberbarmen rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100312",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100312/prognoses",
+        "address": "Rosenau 10, 42277 Wuppertal",
+        "capacity": 21,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "PRBL - Parkraumbewirtschaftung Linne",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.220542,
+          51.274129
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100313",
+        "name": "Tiefgarage Bahnhof Oberbarmen",
+        "type": "underground",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100313",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100313/prognoses",
+        "address": "Rosenau 10, 42277 Wuppertal",
+        "capacity": 32,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "PRBL - Parkraumbewirtschaftung Linne",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 50.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.220752,
+          51.274246
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100314",
+        "name": "Parkplatz Bahnhof Wurzen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100314",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100314/prognoses",
+        "address": "Am Bahnhof, 04808 Wurzen",
+        "capacity": 49,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.50€, 1 Stunde: 1.00€, 1 Tag: 3.50€, 1 Woche: 14.00€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€, 1 Monat Dauerparken (fester Stellplatz): 50.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.739737,
+          51.364743
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-100315",
+        "name": "Parkplatz Zwickau Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=100315",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/100315/prognoses",
+        "address": "Am Bahnhof 1, 08056 Zwickau",
+        "capacity": 23,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.70€, 1 Tag: 5.00€, 1 Woche: 25.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.47656,
+          50.715451
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-102992",
+        "name": "Parkplatz Bahnhof Oberesslingen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=102992",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/102992/prognoses",
+        "address": "Ulmer Straße, 73730 Esslingen am Neckar",
+        "capacity": 134,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.60€, 1 Tag: 2.70€, 1 Woche: 10.80€, 1 Monat (am Automaten): 38.00€, 1 Monat Dauerparken (mind. 3 Monate): 33.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.328485,
+          48.729919
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-102999",
+        "name": "Parkplatz Bahnhof Rommelshausen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=102999",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/102999/prognoses",
+        "address": "Max-Eyth-Straße, 71394 Kernen im Remstal",
+        "capacity": 95,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.00€, 1 Woche: 8.00€, 1 Monat (am Automaten): 22.00€, 1 Monat Dauerparken (mind. 3 Monate): 22.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.319326,
+          48.815109
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103001",
+        "name": "Parkplatz Marbach Kirchenweinbergstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103001",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103001/prognoses",
+        "address": "Kirchenweinbergstraße, 71672 Marbach am Neckar",
+        "capacity": 230,
+        "capacity_disabled": 4,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.20€, 1 Woche: 8.80€, 1 Monat (am Automaten): 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 27.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.264349,
+          48.94387
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103002",
+        "name": "Parkplatz Bahnhof Ehningen Bahnhofstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103002",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103002/prognoses",
+        "address": "Bahnhofstraße, 71139 Ehningen",
+        "capacity": 190,
+        "capacity_disabled": 4,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.20€, 1 Woche: 8.80€, 1 Monat (am Automaten): 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€, 1 Monat Dauerparken (fester Stellplatz): 33.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.941992,
+          48.661421
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103006",
+        "name": "Parkplatz Bahnhof Gärtringen Bahnhofstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103006",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103006/prognoses",
+        "address": "Bahnhofstraße, 71116 Gärtringen",
+        "capacity": 177,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.00€, 1 Woche: 8.00€, 1 Monat (am Automaten): 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.908531,
+          48.641006
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103008",
+        "name": "Parkplatz Bahnhof Ehningen Bühlallee",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103008",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103008/prognoses",
+        "address": "Bühlallee, 71139 Ehningen",
+        "capacity": 53,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.20€, 1 Woche: 8.80€, 1 Monat (am Automaten): 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€, 1 Monat Dauerparken (fester Stellplatz): 33.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.941857,
+          48.662141
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103066",
+        "name": "Kurzzeitparkplatz Passau Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103066",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103066/prognoses",
+        "address": "Bahnhofstraße, 94032 Passau",
+        "capacity": 3,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 1.00€, 1 Stunde: 2.00€, 1 Tag: 6.00€, 1 Woche: 30.00€, 1 Monat Dauerparken (mind. 3 Monate): 75.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          13.451681,
+          48.574133
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-103086",
-        "name": "Tiefgarage Viktoria-Passage / Hauptbahnhof",
+        "name": "Augsburg Tiefgarage Viktoria-Passage / Hbf",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103086",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Augsburg\n86150\nViktoriastraße 2",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103086/prognoses",
+        "address": "Viktoriastraße 2, 86150 Augsburg",
         "capacity": 197,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "06:00-0:30",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 7.00€, 1 Monat Dauerparken (mind. 3 Monate): 120.00€, 1 Monat Dauerparken (fester Stellplatz): 170.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -864,13 +8250,179 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-103096",
+        "name": "Parkplatz Göttingen Bahnhofsallee links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103096",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103096/prognoses",
+        "address": "Bahnhofsallee, 37073 Göttingen",
+        "capacity": 44,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 90.00€, 1 Monat Dauerparken (fester Stellplatz): 155.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.925702,
+          51.537496
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103097",
+        "name": "Bahnhofsplatz Göttingen rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103097",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103097/prognoses",
+        "address": "Bahnhofsplatz, 37073 Göttingen",
+        "capacity": 19,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 90.00€, 1 Monat Dauerparken (fester Stellplatz): 155.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.927248,
+          51.536913
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103098",
+        "name": "Bahnhofsplatz Göttingen links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103098",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103098/prognoses",
+        "address": "Bahnhofsplatz, 37073 Göttingen",
+        "capacity": 7,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 90.00€, 1 Monat Dauerparken (fester Stellplatz): 155.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.926474,
+          51.53617
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103099",
+        "name": "Parkplatz Göttingen am Fahrradparkhaus",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103099",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103099/prognoses",
+        "address": "Berliner Straße, 37073 Göttingen",
+        "capacity": 12,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (mind. 3 Monate): 90.00€, 1 Monat Dauerparken (fester Stellplatz): 155.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.92554,
+          51.53527
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103103",
+        "name": "Parkplatz Hagen Hbf Vorderseite rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103103",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103103/prognoses",
+        "address": "Wehrstraße 1, 58089 Hagen",
+        "capacity": 111,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.10€, 1 Tag: 3.80€, 1 Woche: 26.60€, 1 Monat (am Automaten): 65.00€, 1 Monat Dauerparken (mind. 3 Monate): 65.00€, 1 Monat Dauerparken (fester Stellplatz): 100.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.461533,
+          51.364779
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-103104",
         "name": "Parkhaus Duisburg Hbf / Duisburger Freiheit",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103104",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Duisburg\n47051\nWuhanstraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103104/prognoses",
+        "address": "Wuhanstraße, 47051 Duisburg",
         "capacity": 604,
+        "capacity_disabled": 6,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 15.00€, 1 Tag rabattiert: 12.00€, 1 Monat Dauerparken (mind. 3 Monate): 140.00€, 1 Monat Dauerparken (fester Stellplatz): 200.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -885,12 +8437,23 @@
       "type": "Feature",
       "properties": {
         "id": "db-103119",
-        "name": "Parkplatz Bahnhof Coburg Rückseite",
+        "name": "Parkplatz Bahnhof Coburg Adamistraße",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103119",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Coburg\n96450\nAdamistraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103119/prognoses",
+        "address": "Adamistraße, 96450 Coburg",
         "capacity": 64,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "\t\nAchtung: Wegen Baumaßnahmen ist die Zufahrt über die Adamistraße gesperrt. Der Parkplatz ist über die Callenberger Straße, aus Richtung „Gaudlitz-Kreuzung“ kommend, erreichbar.\n\nDer Zugang zum Bahnhof ist nicht barrierefrei (Treppe).",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.20€, 1 Tag: 6.00€, 1 Woche: 30.00€, 1 Monat (am Automaten): 70.00€, 1 Monat Dauerparken (mind. 3 Monate): 70.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -908,9 +8471,20 @@
         "name": "Parkplatz Bahnhof Geltendorf Vorderseite Nord",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103129",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Geltendorf\n82269\nAm Bahnhof",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103129/prognoses",
+        "address": "Am Bahnhof, 82269 Geltendorf",
         "capacity": 387,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 2.20€, 1 Woche: 8.00€, 1 Monat (am Automaten): 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -925,12 +8499,23 @@
       "type": "Feature",
       "properties": {
         "id": "db-103130",
-        "name": "Tiefgarage Hauptbahnhof Süd / Karlsruher Straße",
+        "name": "Frankfurt (Main) Tiefgarage Hbf Süd / Karlsruher Straße",
         "type": "underground",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103130",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Frankfurt am Main\n60329\nKarlsruher Straße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103130/prognoses",
+        "address": "Karlsruher Straße, 60329 Frankfurt am Main",
         "capacity": 81,
+        "capacity_disabled": 3,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 3.50€, 1 Tag: 33.00€, 1 Monat Dauerparken (mind. 3 Monate): 300.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -944,13 +8529,241 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-103132",
+        "name": "Parkplatz Bahnhof Eberbach Bahnhofsplatz",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103132",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103132/prognoses",
+        "address": "Bahnhofsplatz, 69412 Eberbach",
+        "capacity": 75,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 3.30€, 1 Woche: 13.20€, 1 Monat (am Automaten): 28.00€, 1 Monat Dauerparken (mind. 3 Monate): 28.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.983177,
+          49.465874
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103133",
+        "name": "Parkhaus Bahnhof Gießen Lahnstraße P1",
+        "type": "garage",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103133",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103133/prognoses",
+        "address": "Am Güterbahnhof 56, 35398 Gießen",
+        "capacity": 451,
+        "capacity_disabled": 14,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 4.50€, 1 Monat Dauerparken (mind. 3 Monate): 75.00€, 1 Monat Dauerparken (fester Stellplatz): 120.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.662565,
+          50.5812
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103134",
+        "name": "Parkplatz Bahnhof Leinfelden Vorderseite / West",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103134",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103134/prognoses",
+        "address": "Bahnhofstraße, 70771 Leinfelden-Echterdingen",
+        "capacity": 79,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Achtung: Wegen des diesjährigen Filderkrautfestes steht der Parkplatz vom 12. bis 16.10.2023 nicht zur Verfügung.",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 2.50€, 1 Woche: 32.50€, 1 Monat Dauerparken (mind. 3 Monate): 30.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.142557,
+          48.696545
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103158",
+        "name": "Parkplatz Duisburg Hbf Wuhanstraße",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103158",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103158/prognoses",
+        "address": "Wuhanstraße, 47057 Duisburg",
+        "capacity": 15,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 3 Tage",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 15.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.774065,
+          51.427854
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103198",
+        "name": "Parkplatz Erfurt Hbf Zum Güterbahnhof",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103198",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103198/prognoses",
+        "address": "Zum Güterbahnhof, 99085 Erfurt",
+        "capacity": 139,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 3.30€, 1 Woche: 16.50€, 1 Monat (am Automaten): 42.00€, 1 Monat Dauerparken (mind. 3 Monate): 42.00€, 1 Monat Dauerparken (fester Stellplatz): 75.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.044667,
+          50.974216
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103236",
+        "name": "Parkplatz Bahnhof Tutzing Vorderseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103236",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103236/prognoses",
+        "address": "Bahnhofstraße und Heinrich-Vogl-Straße, 82327 Tutzing",
+        "capacity": 145,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 1.80€, 1 Woche: 9.00€, 1 Monat (am Automaten): 22.00€, 1 Monat Dauerparken (mind. 3 Monate): 22.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.273612,
+          47.907691
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103237",
+        "name": "Parkplatz Bahnhof Tutzing Rückseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103237",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103237/prognoses",
+        "address": "Beringerweg, 82327 Tutzing",
+        "capacity": 167,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 1.80€, 1 Woche: 9.00€, 1 Monat (am Automaten): 22.00€, 1 Monat Dauerparken (mind. 3 Monate): 22.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.272244,
+          47.907007
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-103238",
         "name": "Parkhaus Bahnhof Gießen Lahnstraße P2",
         "type": "garage",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103238",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Gießen\n35398\nLahnstraße",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103238/prognoses",
+        "address": "Lahnstraße, 35398 Gießen",
         "capacity": 420,
+        "capacity_disabled": 6,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 4.50€, 1 Monat Dauerparken (mind. 3 Monate): 75.00€, 1 Monat Dauerparken (fester Stellplatz): 120.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -964,13 +8777,303 @@
     {
       "type": "Feature",
       "properties": {
+        "id": "db-103239",
+        "name": "Parkplatz Bahnhof Gießen Lahnstraße P3",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103239",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103239/prognoses",
+        "address": "Lahnstraße, 35398 Gießen",
+        "capacity": 65,
+        "capacity_disabled": 3,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.80€, 1 Stunde: 1.60€, 1 Tag: 5.50€, 1 Woche: 33.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.661266,
+          50.580547
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103259",
+        "name": "Parkplatz Erfurt Hbf Fußgängerbrücke",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103259",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103259/prognoses",
+        "address": "Zum Güterbahnhof, 99085 Erfurt",
+        "capacity": 11,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 1 Woche",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 5.00€, 1 Woche: 25.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.042736,
+          50.97441
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103287",
+        "name": "Parkplatz Bahnhof Düren Lagerstraße am Gleis",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103287",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103287/prognoses",
+        "address": "Lagerstraße, 52349 Düren",
+        "capacity": 235,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 11 Tage oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.70€, 1 Tag: 3.30€, 1 Woche: 16.50€, 1 Monat (am Automaten): 33.00€, 1 Monat Dauerparken (mind. 3 Monate): 33.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.484074,
+          50.80992
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103306",
+        "name": "Tiefgarage Bahnhof Hamburg-Harburg",
+        "type": "underground",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103306",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103306/prognoses",
+        "address": "Hannoversche Straße, 21080 Hamburg",
+        "capacity": 49,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Monat Dauerparken (fester Stellplatz): 120.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          9.989765,
+          53.456208
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103309",
+        "name": "Vorfahrt Ludwigshafen (Rhein) Hbf",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103309",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103309/prognoses",
+        "address": "Pasadenaallee, 67059 Ludwigshafen",
+        "capacity": 44,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.60€, 1 Stunde: 1.20€, 1 Tag: 3.20€, 1 Woche: 12.80€, 1 Monat (am Automaten): 36.00€, 1 Monat Dauerparken (mind. 3 Monate): 36.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.434508,
+          49.478286
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103370",
+        "name": "Parkplatz Bahnhof Villingen",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103370",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103370/prognoses",
+        "address": "Bahnhofstr., 78048 Villingen",
+        "capacity": 48,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen am Automaten",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.20€, 1 Tag: 4.00€, 1 Woche: 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 60.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.465565,
+          48.056921
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103394",
+        "name": "Parkhaus Mannheim Hbf P5",
+        "type": "garage",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103394",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103394/prognoses",
+        "address": "Glücksteinallee 9, 68163 Mannheim",
+        "capacity": 100,
+        "capacity_disabled": 6,
+        "capacity_charging": 1,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Mannheimer Parkhausbetriebe GmbH",
+        "description": "Infoflyer als PDF",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag rabattiert: 10.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.469447,
+          49.47738
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103449",
+        "name": "Parkplatz Bahnhof Bad Endorf Rückseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103449",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103449/prognoses",
+        "address": "Geigelsteinstraße, 83093 Bad Endorf",
+        "capacity": 137,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 1.50€, 1 Woche: 6.00€, 1 Monat (am Automaten): 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 15.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          12.301518,
+          47.904755
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103478",
+        "name": "Parkplatz Bahnhof Lauf rechts der Pegnitz",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103478",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103478/prognoses",
+        "address": "Raiffeisenstraße, 91207 Lauf an der Pegnitz",
+        "capacity": 75,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.00€, 1 Tag: 4.00€, 1 Woche: 16.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.278799,
+          49.512878
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
         "id": "db-103486",
-        "name": "Bahnhof Stuttgart-Vaihingen: Reservierbare PKW-Stellplätze",
+        "name": "Parkplatz Bahnhof Stuttgart-Vaihingen buchbare PKW-Stellplätze",
         "type": "lot",
         "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103486",
-        "source_url": "https://api.deutschebahn.com/bahnpark/v1/spaces/occupancies",
-        "address": "Stuttgart\n70563\nBahnhof (Vaihingen) 1",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103486/prognoses",
+        "address": "Bahnhof (Vaihingen) 1, 70563 Stuttgart",
         "capacity": 7,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Tag: 3.00€, 1 Woche: 15.00€",
+        "park_ride": true,
         "has_live_capacity": true
       },
       "geometry": {
@@ -978,6 +9081,378 @@
         "coordinates": [
           9.113839,
           48.727162
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103634",
+        "name": "Parkplatz Bahnhof Zorneding Vorderseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103634",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103634/prognoses",
+        "address": "Bahnhofstraße, 85604 Zorneding",
+        "capacity": 118,
+        "capacity_disabled": 4,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.00€, 1 Woche: 8.00€, 1 Monat (am Automaten): 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.831683,
+          48.089437
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103635",
+        "name": "Parkplatz Bahnhof Zorneding Rückseite",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103635",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103635/prognoses",
+        "address": "Anzingerstraße, 85604 Zorneding",
+        "capacity": 80,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.00€, 1 Woche: 8.00€, 1 Monat (am Automaten): 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.831101,
+          48.090035
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103670",
+        "name": "Parkplatz Bahnhof Wolfratshausen Vorderseite rechts",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103670",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103670/prognoses",
+        "address": "Sauerlacher Straße, 82515 Wolfratshausen",
+        "capacity": 40,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 1.60€, 1 Woche: 8.00€, 1 Monat (am Automaten): 18.00€, 1 Monat Dauerparken (mind. 3 Monate): 18.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.426099,
+          47.913458
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103671",
+        "name": "Parkplatz Bahnhof Wolfratshausen Vorderseite links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103671",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103671/prognoses",
+        "address": "Am Floßkanal und Bahnhofstraße, 82515 Wolfratshausen",
+        "capacity": 105,
+        "capacity_disabled": 2,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 1.60€, 1 Woche: 8.00€, 1 Monat (am Automaten): 18.00€, 1 Monat Dauerparken (mind. 3 Monate): 18.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.427084,
+          47.915397
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103673",
+        "name": "Parkplatz Bahnhof Lichtenfels am Gleis links",
+        "type": "lot",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103673",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103673/prognoses",
+        "address": "Bgm.-Dr.-Hauptmann-Ring/Zweigstraße, 96215 Lichtenfels",
+        "capacity": 15,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": null,
+        "has_fee": true,
+        "fee_description": "30 Minuten: 0.70€, 1 Stunde: 1.40€, 1 Tag: 3.50€, 1 Woche: 14.00€, 1 Monat (am Automaten): 40.00€, 1 Monat Dauerparken (mind. 3 Monate): 40.00€",
+        "park_ride": true,
+        "has_live_capacity": true
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.061236,
+          50.147048
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-103900",
+        "name": "Parkhaus Bonn-City / Hauptbahnhof",
+        "type": "garage",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=103900",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/103900/prognoses",
+        "address": "Am Alten Friedhof, 53111 Bonn",
+        "capacity": 258,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Einfach parken! (Kurzanleitung als PDF)",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 4.50€, 1 Monat Dauerparken (mind. 3 Monate): 110.00€, 1 Monat Dauerparken (fester Stellplatz): 160.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          7.091883,
+          50.734964
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-104374",
+        "name": "Tiefgarage Darmstadt Hbf",
+        "type": "underground",
+        "public_url": "https://www.dbbahnpark.de/standorte/karte/#parkraum=104374",
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/104374/prognoses",
+        "address": "Poststraße 4-6, 64293 Darmstadt",
+        "capacity": 180,
+        "capacity_disabled": 6,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": null,
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "Einfach parken! (Kurzanleitung als PDF)",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 1.50€, 1 Tag: 3.00€, 1 Monat Dauerparken (mind. 3 Monate): 99.00€, 1 Monat Dauerparken (fester Stellplatz): 149.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          8.631737,
+          49.874228
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-104523",
+        "name": "Parkplatz Bahnhof Dachau Rückseite Ost am Bahnhof",
+        "type": "lot",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/104523/prognoses",
+        "address": "Obere Moosschwaigestraße, 85221 Dachau",
+        "capacity": 111,
+        "capacity_disabled": 0,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.00€, 1 Woche: 8.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€, 1 Monat (am Automaten): 22.00€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.445147,
+          48.254021
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-104524",
+        "name": "Parkplatz Bahnhof Dachau Rückseite Ost",
+        "type": "lot",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/104524/prognoses",
+        "address": "Obere Moosschwaigestraße, 85221 Dachau",
+        "capacity": 155,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.00€, 1 Woche: 8.00€, 1 Monat (am Automaten): 22.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€",
+        "park_ride": true,
+        "has_live_capacity": false
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.445823,
+          48.254007
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-104525",
+        "name": "Parkplatz Bahnhof Dachau Rückseite Ost am Feld",
+        "type": "lot",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/104525/prognoses",
+        "address": "Obere Moosschwaigestraße, 85221 Dachau",
+        "capacity": 284,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.00€, 1 Woche: 8.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€, 1 Monat (am Automaten): 22.00€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.446674,
+          48.253932
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-104526",
+        "name": "Parkplatz Bahnhof Dachau Rückseite Ost am Gleis",
+        "type": "lot",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/104526/prognoses",
+        "address": "Obere Moosschwaigestraße, 85221 Dachau",
+        "capacity": 30,
+        "capacity_disabled": null,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "Max. 2 Wochen oder Monatsparkschein",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 0.50€, 1 Tag: 2.00€, 1 Woche: 8.00€, 1 Monat (am Automaten): 22.00€, 1 Monat Dauerparken (mind. 3 Monate): 20.00€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          11.445326,
+          48.25299
+        ]
+      }
+    },
+    {
+      "type": "Feature",
+      "properties": {
+        "id": "db-104528",
+        "name": "Parkhaus Köln Altstadt-Nord / Hbf (vormals RheinTriadem)",
+        "type": "garage",
+        "public_url": null,
+        "source_url": "https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities/104528/prognoses",
+        "address": "Servasgasse / Am Alten Ufer 35, 50668 Köln",
+        "capacity": 606,
+        "capacity_disabled": 1,
+        "capacity_charging": 0,
+        "capacity_women": null,
+        "capacity_carsharing": null,
+        "opening_hours": "24/7",
+        "max_stay": "",
+        "operator": "Contipark Parkgaragengesellschaft mbH",
+        "description": "",
+        "has_fee": true,
+        "fee_description": "1 Stunde: 2.00€, 1 Tag: 20.00€, 1 Monat Dauerparken (mind. 3 Monate): 195.00€",
+        "park_ride": true,
+        "has_live_capacity": null
+      },
+      "geometry": {
+        "type": "Point",
+        "coordinates": [
+          6.961617,
+          50.944214
         ]
       }
     }

--- a/new/bahn.py
+++ b/new/bahn.py
@@ -1,24 +1,27 @@
 """
 Scraper for Deutsche Bahn parking lots
 
-This scraper is disabled unless you define your API token, either in
-- environment: e.g. `export BAHN_API_TOKEN=xxx` before running the scraper
-- or in a `.env` file in the root of the scraper package containing: `BAHN_API_TOKEN=xxx`
+This scraper is disabled unless you define your DB credentials, either in
+- environment: e.g. `export DB_CLIENT_ID=xxx && export DB_API_KEY=yyy` before running the scraper
+- or in a `.env` file in the root of the scraper package containing: `DB_CLIENT_ID=xxx DB_API_KEY=yyy`
 """
 
+import logging
 import warnings
-from typing import List
+from typing import List, Optional
 
 from decouple import config
 
 from util import *
 
-BAHN_API_TOKEN = config("BAHN_API_TOKEN", None)
+DB_CLIENT_ID = config("DB_CLIENT_ID", None)
+DB_API_KEY = config("DB_API_KEY", None)
 
-if not BAHN_API_TOKEN:
+
+if not DB_CLIENT_ID or not DB_API_KEY:
     warnings.warn(
         "Deutsche Bahn Parking API disabled! "
-        "You need to define BAHN_API_TOKEN in environment or in a .env file"
+        "You need to define DB_CLIENT_ID and DB_API_KEY in environment or in a .env file"
     )
 
 else:
@@ -27,52 +30,83 @@ else:
 
         POOL = PoolInfo(
             id="bahn",
-            name="Deutsche Bahn Parkplätze API",
+            name="BizHub // Parking Information // DB Bahnpark 2.3.847",
             public_url="https://data.deutschebahn.com/dataset/api-parkplatz.html",
-            source_url="https://api.deutschebahn.com/bahnpark/v1/spaces",
-            timezone="Europe/Berlin",  # i guess
-            attribution_license="Creative Commons Attribution 4.0 International (CC BY 4.0)",
-            attribution_contributor="DB BahnPark GmbH",
+            source_url="https://apis.deutschebahn.com/db-api-marketplace/apis/parking-information/db-bahnpark/v2/parking-facilities",
+            timezone="Europe/Berlin",
+            attribution_license="Proprietary Licence DB Bahnpark GmbH",
+            attribution_contributor="DB Bahnpark GmbH",
         )
 
         HEADERS = {
-            "Authorization": f"Bearer {BAHN_API_TOKEN}"
+            "DB-Client-Id": f"{DB_CLIENT_ID}",
+            "DB-Api-Key": f"{DB_API_KEY}"
         }
 
         # TODO: This is really not translatable to numbers
         #   that are meaningful in all cases..
         ALLOCATION_TEXT_TO_NUM_FREE_MAPPING = {
             "bis 10": 5,
-            "> 10": 11,
-            "> 30": 31,
-            "> 50": 51,
+            ">10": 11,
+            ">30": 31,
+            ">50": 51,
         }
+
+        FEE_DURATION_MAPPPING = {
+            "20min": "20 Minuten",
+            "30min": "30 Minuten",
+            "1hour": "1 Stunde",
+            "1day": "1 Tag",
+            "1dayDiscount": "1 Tag rabattiert",
+            "1week": "1 Woche",
+            "1weekDiscount": "1 Woche rabattiert",
+            "1monthVendingMachine": "1 Monat (am Automaten)",
+            "1monthLongTerm": "1 Monat Dauerparken (mind. 3 Monate)",
+            "1monthReservation": "1 Monat Dauerparken (fester Stellplatz)",
+        }
+
+
+        def __init__(self, caching):
+            super().__init__(caching)
+            self.log = logging.getLogger(__name__)
 
         def get_lot_data(self) -> List[LotData]:
             now = self.now()
-            data = self.request_json(
-                self.POOL.source_url + "/occupancies",
-            )
 
-            lots = []
-            for alloc in data["allocations"]:
-                space, alloc = alloc["space"], alloc["allocation"]
+            facilities = self.get_lot_infos_from_geojson()
+            if not facilities:
+                return []
+                
+            lots = []    
+            for facility in facilities:
+                id = facility.id
+                if not facility.has_live_capacity:
+                    self.log.debug(f"Parking {id} has no realtime data, skipping." )
+                    continue
 
-                # --- time segment ---
+                if not ', 7' in facility.address:
+                    # TODO instead do spatial filtering
+                    self.log.debug(f"Parking {id} is not in postal code area 7, skipping." )
+                    continue
 
+                prognosis = self.request_json(
+                    facility.source_url,
+                )
+                alloc = prognosis["_embedded"][0]['occupancy']
+                
+                # --- lot_timestamp ---
                 lot_timestamp = alloc.get("timeSegment")
                 if lot_timestamp:
-                    lot_timestamp = self.to_utc_datetime(lot_timestamp)
-
+                    lot_timestamp = self.to_utc_datetime(lot_timestamp, timezone="utc")   
+                
                 # --- status ---
-
                 status = LotData.Status.nodata
                 if alloc.get("validData"):
                     status = LotData.Status.open
 
-                # --- num free ---
-
-                num_free_text = alloc.get("text")
+                # --- num free & capacity ---
+                capacity = alloc.get("capacity")
+                num_free_text = alloc.get("vacancyText")
                 num_free = None
 
                 if not num_free_text:
@@ -83,49 +117,94 @@ else:
 
                 lots.append(
                     LotData(
-                        id=name_to_id("db", space["id"]),
+                        id=id,
                         timestamp=now,
                         lot_timestamp=lot_timestamp,
                         status=status,
                         num_free=num_free,
-                        capacity=alloc.get("capacity"),
+                        capacity=capacity,
                     )
                 )
 
-            return lots
+           return lots
 
+        def get_capacity(self, facility, type = 'PARKING') -> Optional[int]:
+            for capacity in facility["capacity"]:
+                if capacity['type'] == type and capacity['total'].isnumeric():
+                    return int(capacity['total'])
+                
+            return None
+        
+        def get_opening_hours(self, facility) -> str:
+            facility_opening_hours = facility["access"]["openingHours"]
+            if facility_opening_hours["is24h"] == True:
+                return "24/7"
+            else:
+                # TODO Clean up and osm hours validation
+                oh_text = facility_opening_hours.get("text", '')
+                return oh_text.split('.')[0].split(', Ausfahrt')[0].split('.')[0].replace(': ',' ').replace(' Uhr','').replace(', Sa,So+F geschlossen','').replace(', So+F geschlossen','').replace(' - ','-')
+
+        def get_fee_description(self, facility) -> str:
+            fees = filter(lambda fee: fee["price"] != None and fee['group']['groupName']=='standard', facility["tariff"]["prices"])
+            fee_strings = [f'{self.FEE_DURATION_MAPPPING[fee["duration"]]}: {fee["price"]:.2f}€' for fee in fees] 
+            return ', '.join(fee_strings)
+        
+        def get_max_stay(self, facility):
+            tariffMaxParkingTime = facility["tariff"]["information"]["dynamic"].get("tariffMaxParkingTime")
+            return tariffMaxParkingTime
+
+        def get_address(self, facility):
+            facility_address =facility["address"]
+            zip_and_city = " ".join([facility_address.get("zip"), facility_address.get("city")])
+            return ", ".join([facility_address.get("streetAndNumber"), zip_and_city])
+        
+        def should_ignore(self, facility):
+            id = facility["id"]
+            if facility["access"]["outOfService"]["isOutOfService"] == True:
+                self.log.warning(f'Parking {id} is out of service. Skipping.')
+                return True
+            if not "capacity" in facility:
+                # ignore facilities with no capacity info 
+                self.log.warning(f'Parking {id} has no capacity. Skipping.')
+                return True
+            
         def get_lot_infos(self) -> List[LotInfo]:
-            spaces = []
-
-            offset = 0
-            while True:
-                data = self.request_json(
-                    self.POOL.source_url,
-                    params={"offset": offset, "limit": 100}
-                )
-                spaces += data["items"]
-                if len(spaces) >= data["totalCount"]:
-                    break
-                offset += len(data["items"])
-
+            data = self.request_json(
+                self.POOL.source_url,
+                timeout=60,
+            )
+            facilities = data["_embedded"]
+            
             lots = []
-            for space in spaces:
-                # import json
-                # print(json.dumps(space, indent=2)); exit()
+            for facility in facilities:
+                if self.should_ignore(facility):
+                    # ignore reason is logged by should_ignore
+                    continue
+                
+                id = facility["id"]
+                fee_description = self.get_fee_description(facility)
 
                 lots.append(
                     LotInfo(
-                        id=name_to_id("db", space["id"]),
-                        name=space["name"],
-                        # either street or auto-mapping
-                        type=LotInfo.Types.street if space["spaceType"] == "Straße" else space["spaceType"],
-                        public_url=space["url"],
-                        source_url=self.POOL.source_url + "/occupancies",
-                        address="\n".join(space["address"].values()),
-                        capacity=int(space["numberParkingPlaces"]),
-                        has_live_capacity=True,
-                        latitude=space["geoLocation"]["latitude"],
-                        longitude=space["geoLocation"]["longitude"],
+                        id=name_to_id("db", id),
+                        name=facility["name"][1]["name"], # TODO: which context ["DISPLAY"] or NAME?,
+                        type=facility["type"]["abbreviation"], # lot type guessing should be sufficient
+                        public_url=facility["url"],
+                        source_url=f'{self.POOL.source_url}/{id}/prognoses',
+                        address=self.get_address(facility),
+                        capacity=self.get_capacity(facility, 'PARKING'),
+                        capacity_disabled=self.get_capacity(facility, 'HANDICAPPED_PARKING'),
+                        capacity_charging= 1 if facility["equipment"]["charging"]["hasChargingStation"] == True else 0,
+                        has_live_capacity=facility["hasPrognosis"],
+                        latitude=facility["address"]["location"]["latitude"],
+                        longitude=facility["address"]["location"]["longitude"],
+                        opening_hours = self.get_opening_hours(facility),
+                        operator = facility['operator']['name'],
+                        max_stay = self.get_max_stay(facility),
+                        has_fee = len(fee_description) > 0,
+                        fee_description = fee_description,
+                        park_ride = True,
+                        description = facility["tariff"]["information"]["dynamic"].get("tariffNotes")
                     )
                 )
 

--- a/scraper.py
+++ b/scraper.py
@@ -110,7 +110,7 @@ class JsonPrinter:
         self.first_entry = False
 
         text = json.dumps(data, indent=2, ensure_ascii=False)
-
+        
         if self.levels:
             text = "\n".join("  " * self.levels + line for line in text.splitlines())
         print(text, end="" if self.levels else "\n")
@@ -207,12 +207,16 @@ def main(
             log(f"scraping pool '{pool_id}'")
             scraper = scrapers[pool_id](caching=cache)
             snapshotter = SnapshotMaker(scraper)
-            snapshot = snapshotter.info_map_to_geojson(include_unknown=True)
             if command == "write-geojson":
+                # write-geojson will recreate geojson via get_lot_infos
+                snapshot = snapshotter.info_map_to_geojson(include_all_infos = True, include_unknown=False)
                 filename = Path(inspect.getfile(scraper.__class__)[:-3] + ".geojson")
                 log("writing", filename)
                 filename.write_text(json.dumps(snapshot, indent=2, ensure_ascii=False))
             else:
+                # show-geojson will read geojson and potentially include parkings, which are not yet defined
+                # in geojson with stub information.
+                snapshot = snapshotter.info_map_to_geojson(include_unknown=True)
                 print(json.dumps(snapshot, indent=2, ensure_ascii=False))
 
 

--- a/util/scraper.py
+++ b/util/scraper.py
@@ -111,7 +111,7 @@ class ScraperBase:
             return infos
 
     def get_lot_info_map(self, required: bool = True) -> Dict[str, LotInfo]:
-        lot_infos = self.get_lot_infos_from_geojson()
+        lot_infos = self.get_lot_infos_from_geojson() if not required else None
         if not lot_infos:
             try:
                 lot_infos = self.get_lot_infos()

--- a/util/structs.py
+++ b/util/structs.py
@@ -57,7 +57,18 @@ class LotInfo(Struct):
             source_url: Optional[str] = None,
             address: Optional[str] = None,
             capacity: Optional[int] = None,
+            capacity_disabled: Optional[int] = None,
+            capacity_charging: Optional[int] = None,
+            capacity_women: Optional[int] = None,
+            capacity_carsharing: Optional[int] = None,
             has_live_capacity: bool = False,
+            opening_hours: Optional[str] = None,
+            max_stay: Optional[str] = None,
+            operator: Optional[str] = None,
+            description: Optional[str] = None,
+            has_fee: Optional[bool] = None,
+            fee_description: Optional[str] = None,
+            park_ride: Optional[str] = None, # TODO osm way or two types attributes yes/no _modes 
             latitude: Optional[Union[str, float]] = None,
             longitude: Optional[Union[str, float]] = None,
     ):
@@ -68,6 +79,17 @@ class LotInfo(Struct):
         self.source_url = source_url
         self.address = address or None
         self.capacity = capacity
+        self.capacity_disabled = capacity_disabled
+        self.capacity_charging = capacity_charging
+        self.capacity_women = capacity_women
+        self.capacity_carsharing = capacity_carsharing
+        self.opening_hours = opening_hours
+        self.max_stay = max_stay
+        self.operator = operator
+        self.description = description
+        self.has_fee = has_fee
+        self.fee_description = fee_description
+        self.park_ride = park_ride   
         self.has_live_capacity = has_live_capacity
         self.latitude = latitude
         self.longitude = longitude


### PR DESCRIPTION
This PR adds a converter for DB Bahnpark API 2.3.x.

Note that it requires #1 to be merged.

Note also, that the rate limits imposed bei the Bahnpark imply that this converter can not be used with DB Bahnpark's usual test access.